### PR TITLE
feat(ci): Add GitHub Actions CI, fix CodeQL, update Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,9 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
 version: 2
 updates:
   - package-ecosystem: "nuget"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     target-branch: "master"
     ignore:
       - dependency-name: "Microsoft.Build.Tasks.Core"
@@ -16,4 +11,16 @@ updates:
     labels:
       - "dependencies"
     reviewers:
-      - "mkaring"
+      - "mcpolo99"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "ci"
+    reviewers:
+      - "mcpolo99"
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,15 @@ jobs:
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v2
 
+      - name: Install .NET 4.6.1 targeting pack
+        shell: pwsh
+        run: |
+          $url = 'https://download.microsoft.com/download/F/1/D/F1DEB8DB-D277-4EF9-9F48-3A65D4D8F965/NDP461-DevPack-KB3105179-ENU.exe'
+          $installer = "$env:TEMP\ndp461-devpack.exe"
+          Invoke-WebRequest -Uri $url -OutFile $installer -UseBasicParsing
+          Start-Process -FilePath $installer -ArgumentList '/quiet','/norestart' -Wait
+          Write-Host "Installed .NET 4.6.1 Developer Pack"
+
       - name: Restore
         run: msbuild Confuser2.sln -t:Restore -verbosity:minimal
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,17 @@ jobs:
           Start-Process -FilePath $installer -ArgumentList '/quiet','/norestart' -Wait
           Write-Host "Installed .NET 4.6.1 Developer Pack"
 
+      - name: Install nbgv
+        run: dotnet tool install -g nbgv
+
+      - name: Compute version
+        id: version
+        shell: pwsh
+        run: |
+          $ver = nbgv get-version -v NuGetPackageVersion
+          echo "VERSION=$ver" >> $env:GITHUB_OUTPUT
+          Write-Host "Version: $ver"
+
       - name: Restore
         run: msbuild Confuser2.sln -t:Restore -verbosity:minimal
 
@@ -84,20 +95,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install nbgv
+        run: dotnet tool install -g nbgv
+
       - name: Compute version
         id: version
         shell: pwsh
         run: |
-          $tag = git describe --tags --match "v*" --abbrev=0 2>$null
-          if ($tag) {
-            $clean = $tag -replace '^v', ''
-            $parts = $clean -split '\.'
-            $since = git rev-list "$tag..HEAD" --count
-            $ver = "$($parts[0]).$($parts[1]).$since"
-          } else {
-            $commits = git rev-list HEAD --count
-            $ver = "1.0.$commits"
-          }
+          $ver = nbgv get-version -v NuGetPackageVersion
           echo "VERSION=$ver" >> $env:GITHUB_OUTPUT
           Write-Host "Version: $ver"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,14 +2,14 @@ name: ci
 
 on:
   push:
-    branches: [master]
-    tags: ['v*']
+    branches: [master, feature/**, fix/**]
   pull_request:
     branches: [master]
 
 jobs:
   build:
     runs-on: windows-2022
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v5
         with:
@@ -46,7 +46,6 @@ jobs:
           $zip = 'ConfuserEx.zip'
           $tmp = 'combined'
           New-Item -ItemType Directory -Path $tmp -Force | Out-Null
-          # CLI first, then GUI on top (GUI adds WPF deps)
           Copy-Item 'Confuser.CLI/bin/Release/net461/*' $tmp -Exclude '*.pdb','*.xml' -Recurse
           Copy-Item 'ConfuserEx/bin/Release/net461/*' $tmp -Exclude '*.pdb','*.xml' -Recurse -Force
           Get-ChildItem $tmp | Compress-Archive -DestinationPath $zip
@@ -63,13 +62,46 @@ jobs:
             ConfuserEx.zip
             Confuser.MSBuild.Tasks/bin/Release/*.nupkg
 
+  # Release: only on PR merge to master
   release:
     needs: build
-    if: startsWith(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    runs-on: windows-2022
+    timeout-minutes: 5
     permissions:
       contents: write
     steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Compute version
+        id: version
+        shell: pwsh
+        run: |
+          $tag = git describe --tags --match "v*" --abbrev=0 2>$null
+          if ($tag) {
+            $clean = $tag -replace '^v', ''
+            $parts = $clean -split '\.'
+            $since = git rev-list "$tag..HEAD" --count
+            $ver = "$($parts[0]).$($parts[1]).$since"
+          } else {
+            $commits = git rev-list HEAD --count
+            $ver = "1.0.$commits"
+          }
+          echo "VERSION=$ver" >> $env:GITHUB_OUTPUT
+          Write-Host "Version: $ver"
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Create release tag
+        run: |
+          git tag -a "v${{ steps.version.outputs.VERSION }}" -m "Release ${{ steps.version.outputs.VERSION }}"
+          git push origin "v${{ steps.version.outputs.VERSION }}"
+
       - name: Download artifacts
         uses: actions/download-artifact@v5
         with:
@@ -78,7 +110,8 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          name: ${{ github.ref_name }}
+          tag_name: v${{ steps.version.outputs.VERSION }}
+          name: v${{ steps.version.outputs.VERSION }}
           files: |
             ConfuserEx-CLI.zip
             ConfuserEx-GUI.zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,86 @@
+name: ci
+
+on:
+  push:
+    branches: [master]
+    tags: ['v*']
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: windows-2022
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v2
+
+      - name: Restore
+        run: msbuild Confuser2.sln -t:Restore -verbosity:minimal
+
+      - name: Build
+        run: msbuild Confuser2.sln -p:Configuration=Release -verbosity:minimal
+
+      - name: Package CLI
+        shell: pwsh
+        run: |
+          $src = 'Confuser.CLI/bin/Release/net461'
+          $zip = 'ConfuserEx-CLI.zip'
+          Get-ChildItem $src -Exclude '*.pdb','*.xml' | Compress-Archive -DestinationPath $zip
+          Write-Host "Created $zip ($([math]::Round((Get-Item $zip).Length / 1MB, 1)) MB)"
+
+      - name: Package GUI
+        shell: pwsh
+        run: |
+          $src = 'ConfuserEx/bin/Release/net461'
+          $zip = 'ConfuserEx-GUI.zip'
+          Get-ChildItem $src -Exclude '*.pdb','*.xml' | Compress-Archive -DestinationPath $zip
+          Write-Host "Created $zip ($([math]::Round((Get-Item $zip).Length / 1MB, 1)) MB)"
+
+      - name: Package combined
+        shell: pwsh
+        run: |
+          $zip = 'ConfuserEx.zip'
+          $tmp = 'combined'
+          New-Item -ItemType Directory -Path $tmp -Force | Out-Null
+          # CLI first, then GUI on top (GUI adds WPF deps)
+          Copy-Item 'Confuser.CLI/bin/Release/net461/*' $tmp -Exclude '*.pdb','*.xml' -Recurse
+          Copy-Item 'ConfuserEx/bin/Release/net461/*' $tmp -Exclude '*.pdb','*.xml' -Recurse -Force
+          Get-ChildItem $tmp | Compress-Archive -DestinationPath $zip
+          Remove-Item $tmp -Recurse -Force
+          Write-Host "Created $zip ($([math]::Round((Get-Item $zip).Length / 1MB, 1)) MB)"
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v5
+        with:
+          name: confuserex-packages
+          path: |
+            ConfuserEx-CLI.zip
+            ConfuserEx-GUI.zip
+            ConfuserEx.zip
+            Confuser.MSBuild.Tasks/bin/Release/*.nupkg
+
+  release:
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v5
+        with:
+          name: confuserex-packages
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: ${{ github.ref_name }}
+          files: |
+            ConfuserEx-CLI.zip
+            ConfuserEx-GUI.zip
+            ConfuserEx.zip
+            *.nupkg

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,25 +16,25 @@ permissions:
 jobs:
   analyze:
     name: Analyze
-    runs-on: windows-2019
+    runs-on: windows-2022
 
     strategy:
       fail-fast: false
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v1
+        uses: github/codeql-action/init@v3
         with:
           languages: csharp
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v1
+        uses: github/codeql-action/autobuild@v3
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v1
+        uses: github/codeql-action/analyze@v3

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -33,8 +33,22 @@ jobs:
         with:
           languages: csharp
 
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v2
+
+      - name: Install .NET 4.6.1 targeting pack
+        shell: pwsh
+        run: |
+          $url = 'https://download.microsoft.com/download/F/1/D/F1DEB8DB-D277-4EF9-9F48-3A65D4D8F965/NDP461-DevPack-KB3105179-ENU.exe'
+          $installer = "$env:TEMP\ndp461-devpack.exe"
+          Invoke-WebRequest -Uri $url -OutFile $installer -UseBasicParsing
+          Start-Process -FilePath $installer -ArgumentList '/quiet','/norestart' -Wait
+
+      - name: Restore
+        run: msbuild Confuser2.sln -t:Restore -verbosity:minimal
+
+      - name: Build
+        run: msbuild Confuser2.sln -p:Configuration=Release -verbosity:minimal
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
## Summary
- Add GitHub Actions CI workflow (build, package, release)
- Use NBGV for automatic semantic versioning
- Install .NET 4.6.1 targeting pack for C++ test project
- Fix CodeQL workflow: update from windows-2019/v1 to windows-2022/v3
- Replace CodeQL autobuild with custom MSBuild steps
- Fix Dependabot config: correct reviewer, add github-actions ecosystem, weekly schedule

## Changes from upstream
CI/build improvements only. No protection logic changes.

## Test plan
- [ ] CI build passes on this branch
- [ ] CodeQL analysis completes successfully
- [ ] Release job triggers only on master merge