### PR TITLE
fix(core): support .NET Standard library obfuscation

### DIFF
--- a/Confuser.Core/ConfuserAssemblyResolver.cs
+++ b/Confuser.Core/ConfuserAssemblyResolver.cs
@@ -37,6 +37,13 @@ namespace Confuser.Core {
 				InternalExactResolver.Resolve(assembly, sourceModule) ??
 				InternalFuzzyResolver.Resolve(assembly, sourceModule);
 
+			//	Remove AssemblyAttributes.PA_NoPlatform
+			if (null != resolvedAssemblyDef &&
+				(AssemblyAttributes.PA_Mask & resolvedAssemblyDef.Attributes) == AssemblyAttributes.PA_NoPlatform) {
+				resolvedAssemblyDef.Attributes =
+					resolvedAssemblyDef.Attributes & ~AssemblyAttributes.PA_FullMask;
+			}
+
 			if (resolvedAssemblyDef?.Name == "netstandard" && 0 < resolvedAssemblyDef.ManifestModule.ExportedTypes.Count) {
 				//	Move types from AssemblyRef to here
 				var module = resolvedAssemblyDef.ManifestModule;

--- a/Confuser.Protections/Compress/Compressor.cs
+++ b/Confuser.Protections/Compress/Compressor.cs
@@ -175,7 +175,7 @@ namespace Confuser.Protections {
 			context.Logger.EndProgress();
 		}
 
-		void InjectData(ModuleDef stubModule, MethodDef method, byte[] data) {
+		void InjectData(ConfuserContext context, ModuleDef stubModule, MethodDef method, byte[] data) {
 			var dataType = new TypeDefUser("", "DataType", stubModule.CorLibTypes.GetTypeRef("System", "ValueType"));
 			dataType.Layout = TypeAttributes.ExplicitLayout;
 			dataType.Visibility = TypeAttributes.NestedPrivate;
@@ -197,7 +197,7 @@ namespace Confuser.Protections {
 				repl.Add(Instruction.Create(OpCodes.Dup));
 				repl.Add(Instruction.Create(OpCodes.Ldtoken, dataField));
 				repl.Add(Instruction.Create(OpCodes.Call, stubModule.Import(
-					typeof(RuntimeHelpers).GetMethod("InitializeArray"))));
+					context, typeof(RuntimeHelpers), "InitializeArray")));
 				return repl.ToArray();
 			});
 		}
@@ -254,7 +254,7 @@ namespace Confuser.Protections {
 			MutationHelper.InjectKeys(entryPoint,
 									  new[] { 0, 1 },
 									  new[] { encryptedModule.Length >> 2, (int)seed });
-			InjectData(stubModule, entryPoint, encryptedModule);
+			InjectData(context, stubModule, entryPoint, encryptedModule);
 
 			// Decrypt
 			MethodDef decrypter = defs.OfType<MethodDef>().Single(method => method.Name == "Decrypt");

--- a/Confuser.Protections/Constants/EncodePhase.cs
+++ b/Confuser.Protections/Constants/EncodePhase.cs
@@ -122,7 +122,7 @@ namespace Confuser.Protections.Constants {
 				repl.Add(Instruction.Create(OpCodes.Dup));
 				repl.Add(Instruction.Create(OpCodes.Ldtoken, moduleCtx.DataField));
 				repl.Add(Instruction.Create(OpCodes.Call, moduleCtx.Module.Import(
-					typeof(RuntimeHelpers).GetMethod("InitializeArray"))));
+					context, typeof(RuntimeHelpers), "InitializeArray")));
 				return repl.ToArray();
 			});
 		}

--- a/Confuser.Protections/Resources/InjectPhase.cs
+++ b/Confuser.Protections/Resources/InjectPhase.cs
@@ -137,7 +137,7 @@ namespace Confuser.Protections.Resources {
 				repl.Add(Instruction.Create(OpCodes.Dup));
 				repl.Add(Instruction.Create(OpCodes.Ldtoken, moduleCtx.DataField));
 				repl.Add(Instruction.Create(OpCodes.Call, moduleCtx.Module.Import(
-					typeof(RuntimeHelpers).GetMethod("InitializeArray"))));
+					moduleCtx.Context, typeof(RuntimeHelpers), "InitializeArray")));
 				return repl.ToArray();
 			});
 			moduleCtx.Context.Registry.GetService<IConstantService>().ExcludeMethod(moduleCtx.Context, moduleCtx.InitMethod);

--- a/Confuser.Protections/Utils.cs
+++ b/Confuser.Protections/Utils.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+using Confuser.Core;
+using dnlib.DotNet;
+
+namespace Confuser.Protections {
+	internal static class Utils {
+		public static IMethod Import(this ModuleDef module, ConfuserContext context, Type classType, string method) {
+			var corLib = context.Resolver.Resolve(context.CurrentModule?.CorLibTypes.AssemblyRef, context.CurrentModule);
+			var typeInfo = corLib?.ManifestModule.Find(classType.FullName, true);
+			return (typeInfo == null) ? module.Import(classType.GetMethod(method)) : module.Import(typeInfo.FindMethod(method));
+		}
+	}
+}


### PR DESCRIPTION
Fixes #3

Cherry-pick of mkaring/ConfuserEx#553 — ensures obfuscated .NET Standard libraries remain .NET Standard without mscorlib contamination.

Changes:
- Add types in referencing assembly to netstandard DLL
- Remove AssemblyAttributes.PA_NoPlatform from assembly
- Fix assembly reference to assemblies hidden by netstandard
- Return method from CorLib of module to be confused instead of runtime