### PR TITLE
fix(renamer): fix generic name parsing null case

### DIFF
--- a/Confuser.Renamer/NameService.cs
+++ b/Confuser.Renamer/NameService.cs
@@ -214,7 +214,7 @@ namespace Confuser.Renamer {
 
 		public string ObfuscateName(string format, string name, RenameMode mode, bool preserveGenericParams = false) {
 			int genericParamsCount = 0;
-			if (preserveGenericParams) {
+			if (preserveGenericParams && !string.IsNullOrEmpty(name)) {
 				name = ParseGenericName(name, out genericParamsCount);
 			}
 


### PR DESCRIPTION
Fixes #17

Cherry-pick of mkaring/ConfuserEx#516 — handles null case in generic type name parsing to prevent crashes.