### PR TITLE
fix(protections): revert control flow SwitchMangler logic inversion

### DIFF
--- a/Confuser.Protections/ControlFlow/SwitchMangler.cs
+++ b/Confuser.Protections/ControlFlow/SwitchMangler.cs
@@ -260,16 +260,8 @@ namespace Confuser.Protections.ControlFlow {
 						                    src.Offset >= block.Instructions.Last().Offset))
 							return true;
 
-						// Disable flow obfuscation for blocks reached by jump instructions.
-						// Bug in #153 caused exactly this behaviour, expect for allowing wrong jump instructions
-						// There is another issue present here tracked here:
-						// https://github.com/mkaring/ConfuserEx/issues/162
-						// Until this issue is resolved, the ctrl flow obfuscation will be severely reduced.
-						if (srcs.Any())
-							return true;
-
 						// Not targeted by the last of statements
-						if (srcs.Any(src => !statementLast.Contains(src)))
+						if (srcs.Any(src => statementLast.Contains(src)))
 							return true;
 					}
 					return false;


### PR DESCRIPTION
Fixes #5

Cherry-pick of mkaring/ConfuserEx#562 — reverts a logic inversion introduced in v1.4.0 where statementLast.Contains(src) was incorrectly negated.

Investigation confirmed the bug:
- Original code (yck1509): statementLast.Contains(src) — correct
- v1.4.0 (b4a67cb): flipped to !statementLast.Contains(src) — bug
- Workaround (acbd871): blanket srcs.Any() guard that severely reduced obfuscation effectiveness

This fix reverts to the original logic and removes the overly conservative workaround.