### PR TITLE
feat(core): add wildcard module loading in .crproj

### DIFF
--- a/Confuser.CLI/Program.cs
+++ b/Confuser.CLI/Program.cs
@@ -60,10 +60,8 @@ namespace Confuser.CLI {
 					try {
 						var xmlDoc = new XmlDocument();
 						xmlDoc.Load(files[0]);
-						proj.Load(xmlDoc);
-						string crprojDir = Path.GetDirectoryName(Path.GetFullPath(files[0]));
-						proj.BaseDirectory = Path.GetFullPath(Path.Combine(crprojDir, proj.BaseDirectory));
-						proj.OutputDirectory = Path.GetFullPath(Path.Combine(crprojDir, proj.OutputDirectory));
+						proj.Load(xmlDoc, Path.GetDirectoryName(Path.GetFullPath(files[0])));
+						proj.OutputDirectory = Path.GetFullPath(Path.Combine(proj.BaseDirectory, proj.OutputDirectory));
 					}
 					catch (Exception ex) {
 						WriteLineWithColor(ConsoleColor.Red, "Failed to load project:");

--- a/Confuser.Core/Project/ConfuserProject.cs
+++ b/Confuser.Core/Project/ConfuserProject.cs
@@ -626,7 +626,7 @@ namespace Confuser.Core.Project {
 		/// <exception cref="Confuser.Core.Project.ProjectValidationException">
 		///     The project XML contains schema errors.
 		/// </exception>
-		public void Load(XmlDocument doc) {
+		public void Load(XmlDocument doc, string baseDirRoot = null) {
 			doc.Schemas.Add(Schema);
 			var exceptions = new List<XmlSchemaException>();
 			doc.Validate((sender, e) => {
@@ -641,6 +641,10 @@ namespace Confuser.Core.Project {
 
 			OutputDirectory = docElem.Attributes["outputDir"].Value;
 			BaseDirectory = docElem.Attributes["baseDir"].Value;
+			if (!string.IsNullOrEmpty(baseDirRoot))
+			{
+				BaseDirectory = Path.Combine(baseDirRoot, BaseDirectory);
+			}
 
 			if (docElem.Attributes["seed"] != null)
 				Seed = docElem.Attributes["seed"].Value.NullIfEmpty();
@@ -674,11 +678,44 @@ namespace Confuser.Core.Project {
 					PluginPaths.Add(i.InnerText);
 				}
 				else {
-					var asm = new ProjectModule();
-					asm.Load(i);
-					Add(asm);
+					AddModule(i);
 				}
 			}
+		}
+
+		internal void AddModule(XmlElement elem) {
+			if (IsWildcard(elem.Attributes["path"].Value)) {
+				BatchLoadModules(elem);
+			}
+			else {
+				var asm = new ProjectModule();
+				asm.Load(elem);
+				Add(asm);
+			}
+		}
+
+		internal bool IsWildcard(string path) {
+			return !string.IsNullOrEmpty(path) && path.Contains(@"*");
+		}
+
+		internal bool BatchLoadModules(XmlElement elem) {
+			string wildCardPath = elem.Attributes["path"].Value;
+			string[] files = Directory.GetFiles(BaseDirectory, wildCardPath, SearchOption.TopDirectoryOnly);
+			if (files.Length <= 0)
+			{
+				return false;
+			}
+
+			var asmPrototype = new ProjectModule();
+			asmPrototype.Load(elem);
+
+			foreach (string fileName in files) {
+				var moduleEntry = asmPrototype.Clone();
+				moduleEntry.Path = fileName;
+				Add(moduleEntry);
+			}
+
+			return true;
 		}
 
 		/// <summary>


### PR DESCRIPTION
## Summary

Fixes #18

Cherry-pick of [mkaring/ConfuserEx#481](https://github.com/mkaring/ConfuserEx/pull/481) — allows using wildcards like `*.dll` in module paths within `.crproj` files to batch-load modules.

### Changes

- **`ConfuserProject.Load`** now accepts an optional `baseDirRoot` parameter to resolve the base directory relative to the `.crproj` file location
- New `AddModule` helper dispatches between single-file and wildcard module loading
- New `IsWildcard` and `BatchLoadModules` internal methods handle `Directory.GetFiles` expansion with `SearchOption.TopDirectoryOnly`
- **`Program.cs`** simplified to pass the project file directory into `Load()` instead of manually resolving paths afterward
- `OutputDirectory` is still resolved to a full path relative to the (now-resolved) `BaseDirectory`

### Example usage in `.crproj`

```xml
<module path="*.dll" />
```

This will load all `.dll` files found in the base directory as modules, applying the same protection rules defined on the `<module>` element.

## Test plan

- [ ] Verify existing single-module `.crproj` files still work as before
- [ ] Test wildcard `*.dll` pattern loads all matching modules
- [ ] Verify that non-matching wildcard patterns (no files found) are handled gracefully
- [ ] Confirm `OutputDirectory` resolution still works correctly with relative paths