### PR TITLE
fix(ci): add pre-release branch to CI triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: ci
 
 on:
   push:
-    branches: [master, feature/**, fix/**]
+    branches: [master, pre-release, feature/**, fix/**]
   pull_request:
-    branches: [master]
+    branches: [master, pre-release]
 
 jobs:
   build:


### PR DESCRIPTION
Add pre-release branch to CI push/PR triggers. Release job stays master-only.