### PR TITLE
fix(renamer): serialization-aware renaming exclusions

### DIFF
--- a/Confuser.Renamer/AnalyzePhase.cs
+++ b/Confuser.Renamer/AnalyzePhase.cs
@@ -206,6 +206,10 @@ namespace Confuser.Renamer {
 			if (type.InheritsFrom("System.Configuration.SettingsBase")) {
 				service.SetCanRename(type, false);
 			}
+
+			if (type.HasAttribute("System.Runtime.Serialization.DataContractAttribute")) {
+				service.SetCanRename(type, false);
+			}
 		}
 
 		void Analyze(NameService service, ConfuserContext context, ProtectionParameters parameters, MethodDef method) {
@@ -248,6 +252,12 @@ namespace Confuser.Renamer {
 			else if (field.IsLiteral && field.DeclaringType.IsEnum &&
 				!parameters.GetParameter(context, field, "renEnum", false))
 				service.SetCanRename(field, false);
+
+			else if (field.HasAttribute("System.Runtime.Serialization.DataMemberAttribute"))
+				service.SetCanRename(field, false);
+
+			else if (field.HasAttribute("System.Runtime.Serialization.EnumMemberAttribute"))
+				service.SetCanRename(field, false);
 		}
 
 		void Analyze(NameService service, ConfuserContext context, ProtectionParameters parameters, PropertyDef property) {
@@ -266,6 +276,9 @@ namespace Confuser.Renamer {
 				service.SetCanRename(property, false);
 
 			else if (property.DeclaringType.Name.String.Contains("AnonymousType"))
+				service.SetCanRename(property, false);
+
+			else if (property.HasAttribute("System.Runtime.Serialization.DataMemberAttribute"))
 				service.SetCanRename(property, false);
 		}
 


### PR DESCRIPTION
## Summary
- Detects `[DataContract]` on types and excludes them from renaming
- Detects `[DataMember]` on fields and properties and excludes them from renaming
- Detects `[EnumMember]` on enum fields and excludes them from renaming
- Prevents WCF/DataContract serialization breakage at runtime when rename protection is enabled

Fixes mcpolo99/private-ConfuserEx#9
Upstream: mkaring/ConfuserEx#147

## Approach
Added attribute checks directly in `AnalyzePhase.cs` following the existing pattern used for `[Serializable]`, `[ComImport]`, and other framework attributes. Since `System.Runtime.Serialization` attributes are standard .NET (unlike Newtonsoft.Json which is conditionally registered), the checks run unconditionally — consistent with how `IsSerializable` is already handled on line 249.

The existing `JsonAnalyzer` (registered when `Newtonsoft.Json` is referenced) already handles `[JsonProperty]` exclusions separately.

## Test plan
- [ ] Build succeeds (verified locally: 0 warnings, 0 errors)
- [ ] Obfuscate an assembly containing `[DataContract]`/`[DataMember]` types and verify names are preserved
- [ ] Obfuscate an assembly with `[EnumMember]` enum fields and verify names are preserved
- [ ] Verify normal (non-attributed) types/members are still renamed as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)