### PR TITLE
fix(renamer): preserve anonymous type constructor arg names

### DIFF
--- a/Confuser.Renamer/RenamePhase.cs
+++ b/Confuser.Renamer/RenamePhase.cs
@@ -36,8 +36,13 @@ namespace Confuser.Renamer {
 
 				if (def is MethodDef method) {
 					if ((canRename || method.IsConstructor) && parameters.GetParameter(context, method, "renameArgs", true)) {
-						foreach (var param in method.ParamDefs)
-							param.Name = null;
+						if (method.IsConstructor && method.DeclaringType.Name.String.Contains("AnonymousType")) {
+							// Anonymous type constructor args map to property names — renaming breaks JSON serialization
+						}
+						else {
+							foreach (var param in method.ParamDefs)
+								param.Name = null;
+						}
 					}
 
 					if (parameters.GetParameter(context, method, "renPdb", false) && method.HasBody) {


### PR DESCRIPTION
Fixes #10

When `renameArgs` is enabled, anonymous type constructor parameters get renamed. Since these map directly to property names used in JSON serialization, renaming them breaks Newtonsoft.Json and System.Text.Json.

Skip renaming constructor args for anonymous types while still allowing normal arg renaming elsewhere.