### PR TITLE
fix(renamer): handle FnPtr type signatures without crashing

### DIFF
--- a/Confuser.Renamer/GenericArgumentResolver.cs
+++ b/Confuser.Renamer/GenericArgumentResolver.cs
@@ -122,7 +122,8 @@ namespace Confuser.Renamer {
 					result = new PinnedSig(ResolveGenericArgs(typeSig.Next));
 					break;
 				case ElementType.FnPtr:
-					throw new NotSupportedException("FnPtr is not supported.");
+					result = typeSig;
+					break;
 
 				case ElementType.Array:
 					var arraySig = (ArraySig)typeSig;


### PR DESCRIPTION
Fixes #6

FnPtr (function pointer) type signatures threw `NotSupportedException` in the generic argument resolver, crashing obfuscation of any assembly containing function pointers. Now passes FnPtr signatures through as-is since they don't contain generic parameters that need resolving.