### PR TITLE
fix(renamer): preserve WPF themes/Generic.xaml path

### DIFF
--- a/Confuser.Renamer/Analyzers/WPFAnalyzer.cs
+++ b/Confuser.Renamer/Analyzers/WPFAnalyzer.cs
@@ -60,6 +60,10 @@ namespace Confuser.Renamer.Analyzers {
 					var decodedName = HttpUtility.UrlDecode(doc.DocumentName);
 					var encodedName = doc.DocumentName;
 					if (bamlRefs.TryGetValue(decodedName, out var references)) {
+						// WPF theme resources must keep their conventional paths
+						if (decodedName.IndexOf("themes/generic", StringComparison.OrdinalIgnoreCase) >= 0)
+							continue;
+
 						var decodedLastSlash = decodedName.LastIndexOf('/') + 1;
 						var encodedLastSlash = encodedName.LastIndexOf('/') + 1;
 


### PR DESCRIPTION
Fixes #23

WPF looks for theme resources at the conventional path `themes/Generic.xaml`. Renaming this breaks theme loading and MergedDictionaries that reference it. Now skips renaming for BAML documents containing `themes/generic` in their path.