### PR TITLE
fix(protections): skip unresolvable types in ref proxy phase

### DIFF
--- a/Confuser.Protections/ReferenceProxy/ReferenceProxyPhase.cs
+++ b/Confuser.Protections/ReferenceProxy/ReferenceProxyPhase.cs
@@ -147,7 +147,9 @@ namespace Confuser.Protections.ReferenceProxy {
 					if (operand.MethodSig.ParamsAfterSentinel != null &&
 						operand.MethodSig.ParamsAfterSentinel.Count > 0)
 						continue;
-					TypeDef declType = operand.DeclaringType.ResolveTypeDefThrow();
+					TypeDef declType = operand.DeclaringType.ResolveTypeDef();
+					if (declType == null)
+						continue;
 					// No delegates
 					if (declType.IsDelegate())
 						continue;


### PR DESCRIPTION
Fixes #27

`ReferenceProxyPhase` used `ResolveTypeDefThrow()` on method operands' declaring types, crashing when the type is in an external assembly that isn't loaded (e.g., Unity editor DLLs). Now uses non-throwing `ResolveTypeDef()` and skips unresolvable targets.

Same root cause as #13 (MildMode) but in the shared phase that runs before mode-specific processing.