### PR TITLE
feat(analysis): enable .NET analyzers and configure severity

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -39,6 +39,28 @@ dotnet_style_qualification_for_property = false:suggestion
 dotnet_style_require_accessibility_modifiers = never:info
 
 [*.cs]
+# .NET Analyzer severity overrides
+dotnet_diagnostic.CA1002.severity = none          # Do not expose generic lists (too restrictive for internal code)
+dotnet_diagnostic.CA1031.severity = none          # Do not catch general exceptions (too many existing catch blocks)
+dotnet_diagnostic.CA1032.severity = none          # Implement standard exception constructors
+dotnet_diagnostic.CA1034.severity = none          # Nested types should not be visible
+dotnet_diagnostic.CA1062.severity = none          # Validate arguments of public methods (too noisy initially)
+dotnet_diagnostic.CA1303.severity = none          # Do not pass literals as localized parameters
+dotnet_diagnostic.CA1304.severity = none          # Specify CultureInfo
+dotnet_diagnostic.CA1305.severity = none          # Specify IFormatProvider
+dotnet_diagnostic.CA1307.severity = none          # Specify StringComparison for clarity
+dotnet_diagnostic.CA1310.severity = none          # Specify StringComparison for correctness
+dotnet_diagnostic.CA1707.severity = none          # Identifiers should not contain underscores (test naming)
+dotnet_diagnostic.CA1710.severity = none          # Identifiers should have correct suffix
+dotnet_diagnostic.CA1711.severity = none          # Identifiers should not have incorrect suffix
+dotnet_diagnostic.CA1720.severity = none          # Identifiers should not contain type names
+dotnet_diagnostic.CA1822.severity = suggestion    # Mark members as static (informational only)
+dotnet_diagnostic.CA1825.severity = warning       # Avoid zero-length array allocations
+dotnet_diagnostic.CA1859.severity = suggestion    # Use concrete types for improved performance
+dotnet_diagnostic.CA2000.severity = suggestion    # Dispose objects before losing scope
+dotnet_diagnostic.CA2007.severity = none          # ConfigureAwait (not needed for desktop app)
+dotnet_diagnostic.CA2227.severity = none          # Collection properties should be read only
+
 csharp_indent_block_contents = true
 csharp_indent_braces = false
 csharp_indent_case_contents = true

--- a/ConfuserEx.Common.props
+++ b/ConfuserEx.Common.props
@@ -23,7 +23,8 @@
   </PropertyGroup> 
   
   <PropertyGroup Label="Code Analysis">
-	<EnableCodeAnalysis>false</EnableCodeAnalysis>
+	<EnableNETAnalyzers>true</EnableNETAnalyzers>
+	<AnalysisLevel>latest</AnalysisLevel>
   </PropertyGroup>
   
 </Project>

--- a/ConfuserEx.Common.targets
+++ b/ConfuserEx.Common.targets
@@ -3,8 +3,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.255" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="*" PrivateAssets="all"
-					  Condition="'$(EnableCodeAnalysis)' != 'false'" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.*" PrivateAssets="all"
+					  Condition="'$(EnableNETAnalyzers)' != 'false'" />
   </ItemGroup>
   
 </Project>


### PR DESCRIPTION
Fixes #47

## Changes
- Replace deprecated `Microsoft.CodeAnalysis.FxCopAnalyzers` with `Microsoft.CodeAnalysis.NetAnalyzers 8.*`
- Enable analyzers: `EnableNETAnalyzers=true`, `AnalysisLevel=latest`
- Configure `.editorconfig` with severity overrides:
  - Suppress noisy rules (CA1031, CA1062, CA1303, etc.)
  - Keep useful rules at warning/suggestion (CA1825, CA1822, CA2000)

## Notes
This may surface new warnings in the build output. If CI fails due to analyzer warnings being treated as errors, we'll need to suppress additional rules.