### PR TITLE
fix(analysis): resolve warnings and clean up analyzer config

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -63,6 +63,7 @@ dotnet_diagnostic.CA2227.severity = none          # Collection properties should
 
 # Roslynator severity overrides
 dotnet_diagnostic.RCS1018.severity = none          # Add accessibility modifiers (conflicts with existing style)
+dotnet_diagnostic.RCS1102.severity = none          # Make class static (many are non-static for runtime injection)
 dotnet_diagnostic.RCS1037.severity = none          # Remove trailing white-space
 dotnet_diagnostic.RCS1057.severity = none          # Add empty line between declarations
 dotnet_diagnostic.RCS1085.severity = none          # Use auto-implemented property

--- a/Confuser.Core/ProtectionParameters.cs
+++ b/Confuser.Core/ProtectionParameters.cs
@@ -14,7 +14,7 @@ namespace Confuser.Core {
 		/// <summary>
 		///     A empty instance of <see cref="ProtectionParameters" />.
 		/// </summary>
-		public static readonly ProtectionParameters Empty = new ProtectionParameters(null, new IDnlibDef[0]);
+		public static readonly ProtectionParameters Empty = new ProtectionParameters(null, Array.Empty<IDnlibDef>());
 
 		readonly ConfuserComponent comp;
 

--- a/Confuser.Core/Services/TraceService.cs
+++ b/Confuser.Core/Services/TraceService.cs
@@ -204,7 +204,7 @@ namespace Confuser.Core.Services {
 		public int[] TraceArguments(Instruction instr) {
 			instr.CalculateStackUsage(Method.HasReturnType, out _, out int pop); // pop is number of arguments
 			if (pop == 0)
-				return new int[0];
+				return Array.Empty<int>();
 
 			int instrIndex = offset2index[instr.Offset];
 			int argCount = pop;

--- a/Confuser.Protections/AntiTamper/JITBody.cs
+++ b/Confuser.Protections/AntiTamper/JITBody.cs
@@ -134,7 +134,7 @@ namespace Confuser.Protections.AntiTamper {
 				jitBody.LocalVars = SignatureWriter.Write(metadata, local);
 			}
 			else
-				jitBody.LocalVars = new byte[0];
+				jitBody.LocalVars = Array.Empty<byte>();
 
       {
         var newCode = new byte[codeSize];

--- a/Confuser.Protections/Resources/InjectPhase.cs
+++ b/Confuser.Protections/Resources/InjectPhase.cs
@@ -97,7 +97,7 @@ namespace Confuser.Protections.Resources {
 			moduleCtx.DataField = new FieldDefUser(moduleCtx.Name.RandomName(), new FieldSig(dataType.ToTypeSig())) {
 				IsStatic = true,
 				HasFieldRVA = true,
-				InitialValue = new byte[0],
+				InitialValue = Array.Empty<byte>(),
 				Access = FieldAttributes.CompilerControlled
 			};
 			context.CurrentModule.GlobalType.Fields.Add(moduleCtx.DataField);

--- a/Confuser.Renamer/BAML/PropertyPath/PropertyPathParser.cs
+++ b/Confuser.Renamer/BAML/PropertyPath/PropertyPathParser.cs
@@ -317,7 +317,7 @@ namespace Confuser.Renamer.BAML {
 		ArrayList _al = new ArrayList();
 		const char NullChar = Char.MinValue;
 		const char EscapeChar = '^';
-		static SourceValueInfo[] EmptyInfo = new SourceValueInfo[0];
+		static SourceValueInfo[] EmptyInfo = Array.Empty<SourceValueInfo>();
 		static string SpecialChars = @"./[]";
 	}
 }

--- a/ConfuserEx.Common.targets
+++ b/ConfuserEx.Common.targets
@@ -3,8 +3,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.255" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.*" PrivateAssets="all"
-					  Condition="'$(EnableNETAnalyzers)' != 'false'" />
+    <!-- NetAnalyzers shipped with SDK — no explicit package needed -->
     <PackageReference Include="Roslynator.Analyzers" Version="4.*" PrivateAssets="all"
 					  Condition="'$(EnableNETAnalyzers)' != 'false'" />
   </ItemGroup>


### PR DESCRIPTION
Follow-up to #47 and #48.

- Remove explicit `Microsoft.CodeAnalysis.NetAnalyzers` package (SDK bundles newer version)
- Suppress RCS1102 (make class static) — many classes are non-static intentionally for runtime injection
- Fix all CA1825 warnings: replace `new T[0]` with `Array.Empty<T>()` in 5 files
- Result: zero-warning build