### PR TITLE
fix(core): improve error message for .NET 6+ native host .exe

### DIFF
--- a/Confuser.Core/ObfAttrMarker.cs
+++ b/Confuser.Core/ObfAttrMarker.cs
@@ -326,6 +326,14 @@ namespace Confuser.Core {
 				}
 				catch (BadImageFormatException ex) {
 					context.Logger.ErrorFormat("Failed to load \"{0}\" - Assembly does not appear to be a .NET assembly: \"{1}\".", module.Path, ex.Message);
+					if (module.Path.EndsWith(".exe", StringComparison.OrdinalIgnoreCase)) {
+						var dllPath = Path.ChangeExtension(module.Path, ".dll");
+						var fullDllPath = Path.Combine(proj.BaseDirectory, dllPath);
+						if (File.Exists(fullDllPath))
+							context.Logger.ErrorFormat("Hint: .NET 6+ apps use a native host .exe — try obfuscating \"{0}\" instead.", dllPath);
+						else
+							context.Logger.Error("Hint: For .NET 6+ apps, obfuscate the .dll file, not the .exe (which is a native host stub).");
+					}
 					throw new ConfuserException(ex);
 				}
 			}


### PR DESCRIPTION
Fixes #19
Upstream: mkaring/ConfuserEx#535

When users try to obfuscate a .NET 6+ `.exe` (which is a native host stub, not a managed assembly), the error was just:
```
Failed to load "MyApp.exe" - Assembly does not appear to be a .NET assembly: ".NET data directory RVA is 0".
```

Now adds a helpful hint:
- If a matching `.dll` exists alongside the `.exe`: `Hint: .NET 6+ apps use a native host .exe — try obfuscating "MyApp.dll" instead.`
- Otherwise: `Hint: For .NET 6+ apps, obfuscate the .dll file, not the .exe (which is a native host stub).`