### PR TITLE
feat(core): tolerate missing dependencies — warn instead of crash

### DIFF
--- a/Confuser.Core/ConfuserEngine.cs
+++ b/Confuser.Core/ConfuserEngine.cs
@@ -263,13 +263,10 @@ namespace Confuser.Core {
 			context.Logger.Info("Resolving dependencies...");
 			foreach (var dependency in context.Modules
 											  .SelectMany(module => module.GetAssemblyRefs().Select(asmRef => Tuple.Create(asmRef, module)))) {
-				try {
-					context.Resolver.ResolveThrow(dependency.Item1, dependency.Item2);
-				}
-				catch (AssemblyResolveException ex) {
-					context.Logger.ErrorException("Failed to resolve dependency of '" + dependency.Item2.Name + "'.", ex);
-					throw new ConfuserException(ex);
-				}
+				var resolved = context.Resolver.Resolve(dependency.Item1, dependency.Item2);
+				if (resolved == null)
+					context.Logger.WarnFormat("Failed to resolve dependency '{0}' of '{1}'. Some protections may not work correctly.",
+						dependency.Item1.FullName, dependency.Item2.Name);
 			}
 
 			context.Logger.Debug("Checking Strong Name...");

--- a/Confuser.Core/DnlibUtils.cs
+++ b/Confuser.Core/DnlibUtils.cs
@@ -209,15 +209,12 @@ namespace Confuser.Core {
 		/// <param name="baseType">The full name of base type.</param>
 		/// <returns><c>true</c> if the specified type is inherited from a base type; otherwise, <c>false</c>.</returns>
 		public static bool InheritsFromCorlib(this TypeDef type, string baseType) {
-			if (type.BaseType == null)
-				return false;
-
-			TypeDef bas = type;
-			do {
-				bas = bas.BaseType.ResolveTypeDefThrow();
+			var bas = type.BaseType?.ResolveTypeDef();
+			while (bas != null && bas.DefinitionAssembly.IsCorLib()) {
 				if (bas.ReflectionFullName == baseType)
 					return true;
-			} while (bas.BaseType != null && bas.BaseType.DefinitionAssembly.IsCorLib());
+				bas = bas.BaseType?.ResolveTypeDef();
+			}
 			return false;
 		}
 
@@ -228,15 +225,12 @@ namespace Confuser.Core {
 		/// <param name="baseType">The full name of base type.</param>
 		/// <returns><c>true</c> if the specified type is inherited from a base type; otherwise, <c>false</c>.</returns>
 		public static bool InheritsFrom(this TypeDef type, string baseType) {
-			if (type.BaseType == null)
-				return false;
-
-			TypeDef bas = type;
-			do {
-				bas = bas.BaseType.ResolveTypeDefThrow();
+			var bas = type.BaseType?.ResolveTypeDef();
+			while (bas != null) {
 				if (bas.ReflectionFullName == baseType)
 					return true;
-			} while (bas.BaseType != null);
+				bas = bas.BaseType?.ResolveTypeDef();
+			}
 			return false;
 		}
 
@@ -247,18 +241,12 @@ namespace Confuser.Core {
 		/// <param name="fullName">The full name of the type of interface.</param>
 		/// <returns><c>true</c> if the specified type implements the interface; otherwise, <c>false</c>.</returns>
 		public static bool Implements(this TypeDef type, string fullName) {
-			do {
-				foreach (InterfaceImpl iface in type.Interfaces) {
-					if (iface.Interface.ReflectionFullName == fullName)
-						return true;
-				}
-
-				if (type.BaseType == null)
-					return false;
-
-				type = type.BaseType.ResolveTypeDefThrow();
-			} while (type != null);
-			throw new UnreachableException();
+			while (type != null) {
+				if (type.Interfaces.Any(iface => iface.Interface.ReflectionFullName == fullName))
+					return true;
+				type = type.BaseType?.ResolveTypeDef();
+			}
+			return false;
 		}
 
 		/// <summary>
@@ -451,8 +439,8 @@ namespace Confuser.Core {
 
 			if (method.IsPublic && method.IsNewSlot) {
 				foreach (var iFace in method.DeclaringType.Interfaces) {
-					var iFaceDef = iFace.Interface.ResolveTypeDefThrow();
-					if (iFaceDef.FindMethod(method.Name, (MethodSig)method.Signature) != null)
+					var iFaceDef = iFace.Interface.ResolveTypeDef();
+					if (iFaceDef != null && iFaceDef.FindMethod(method.Name, (MethodSig)method.Signature) != null)
 						return true;
 				}
 			}


### PR DESCRIPTION
Fixes #4
Upstream: mkaring/ConfuserEx#155

## Problem
ConfuserEx crashes during the Inspection phase if ANY assembly dependency cannot be resolved, even if that dependency isn't needed for the protections being applied.

## Fix

### Inspection phase (ConfuserEngine.cs)
- Replace `ResolveThrow` with `Resolve` (non-throwing)
- Log a warning for unresolved dependencies instead of crashing
- Obfuscation continues with best-effort results

### DnlibUtils.cs — null-safe type resolution
- `InheritsFromCorlib`: use `ResolveTypeDef()` with null check instead of `ResolveTypeDefThrow()`
- `InheritsFrom`: same pattern
- `Implements`: same pattern, removed unreachable `throw`
- `IsImplicitImplementedInterfaceMember`: same pattern

These are the core changes from upstream PR #155 (which touched 215 files). The rest of that PR was project restructuring and test deletions — not applicable to our fork.

## Impact
Assemblies with missing third-party dependencies can now be obfuscated. Protections that need the missing types will skip them gracefully (via our earlier fixes in PRs #42, #43, #45).