### PR TITLE
feat(renamer): opt-in overload confusion for method renaming

### DIFF
--- a/Confuser.Renamer/RenamePhase.cs
+++ b/Confuser.Renamer/RenamePhase.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Confuser.Core;
@@ -14,8 +15,12 @@ namespace Confuser.Renamer {
 
 		public override string Name => "Renaming";
 
+		// Tracks overload confusion name assignments: TypeDef -> list of assigned names
+		readonly Dictionary<TypeDef, List<string>> _overloadNames = new Dictionary<TypeDef, List<string>>();
+
 		protected override void Execute(ConfuserContext context, ProtectionParameters parameters) {
 			var service = (NameService)context.Registry.GetService<INameService>();
+			bool overloadConfusion = parameters.GetParameter(context, context.CurrentModule, "overload", false);
 
 			context.Logger.Debug("Renaming...");
 			foreach (var renamer in service.Renamers) {
@@ -84,7 +89,12 @@ namespace Confuser.Renamer {
 					RenameGenericParameters(typeDef.GenericParameters);
 				}
 				else if (def is MethodDef methodDef) {
-					methodDef.Name = service.ObfuscateName(methodDef, mode);
+					if (overloadConfusion && CanApplyOverloadConfusion(methodDef, service)) {
+						methodDef.Name = GetOverloadName(methodDef, service, mode);
+					}
+					else {
+						methodDef.Name = service.ObfuscateName(methodDef, mode);
+					}
 					RenameGenericParameters(methodDef.GenericParameters);
 				}
 				else
@@ -117,6 +127,48 @@ namespace Confuser.Renamer {
 		{
 			foreach (var param in genericParams)
 				param.Name = ((char) (param.Number + 1)).ToString();
+		}
+
+		/// <summary>
+		///     Determines whether overload confusion can safely be applied to the method.
+		///     Only applies to non-virtual, non-interface, non-special methods.
+		/// </summary>
+		static bool CanApplyOverloadConfusion(MethodDef method, INameService service) {
+			if (method.IsVirtual || method.IsAbstract || method.IsConstructor)
+				return false;
+			if (method.IsSpecialName || method.IsRuntimeSpecialName)
+				return false;
+			// Skip if method has override/sibling references (VTable constrained)
+			var refs = service.GetReferences(method);
+			if (refs.Any(r => r.ShouldCancelRename || r.DelayRenaming(service, method)))
+				return false;
+			return true;
+		}
+
+		/// <summary>
+		///     Gets a shared overload name for the method's declaring type.
+		///     Methods with different signatures in the same type get the same name.
+		/// </summary>
+		string GetOverloadName(MethodDef method, NameService service, RenameMode mode) {
+			var declType = method.DeclaringType;
+			if (!_overloadNames.TryGetValue(declType, out var names)) {
+				names = new List<string>();
+				_overloadNames[declType] = names;
+			}
+
+			// Check if any existing name can be reused (different signature = safe to share)
+			foreach (var existingName in names) {
+				bool signatureConflict = declType.Methods.Any(m =>
+					m.Name == existingName &&
+					new SigComparer().Equals(m.MethodSig, method.MethodSig));
+				if (!signatureConflict)
+					return existingName;
+			}
+
+			// No reusable name — generate a new one
+			var newName = service.ObfuscateName(method, mode);
+			names.Add(newName);
+			return newName;
 		}
 
 		static IEnumerable<IDnlibDef> GetTargetsWithDelay(IList<IDnlibDef> definitions, ConfuserContext context, INameService service) {


### PR DESCRIPTION
Fixes #25
Upstream: mkaring/ConfuserEx#230

## Feature
Adds opt-in overload confusion: methods with different signatures in the same type are renamed to the same name. This is valid .NET IL since the CLR distinguishes methods by full signature, not name alone. Makes decompiled output significantly harder to read.

## Usage
```xml
<rule pattern="true" preset="none" inherit="false">
  <protection id="rename">
    <argument name="overload" value="true" />
  </protection>
</rule>
```

**Disabled by default** — must be explicitly opted in via `overload=true`.

## Safety constraints
Only applies to methods that are:
- Non-virtual, non-abstract (no VTable constraints)
- Non-constructor, non-special-name
- Not blocked by INameReference (no override/sibling links)

Virtual methods, interface implementations, and VTable-constrained methods are always excluded.

## How it works
- Per-type name pool tracks assigned overload names
- For each eligible method, checks if an existing name can be reused (no signature conflict)
- If a method with the same `MethodSig` already has that name in the type, generates a new name instead
- Falls back to normal unique naming for ineligible methods

## Risk
Low — opt-in only, constrained to private/non-virtual methods, validated against signature conflicts. Stack trace decoding will not work for overloaded names (documented trade-off).