### PR TITLE
feat(ci): add pre-release builds with downloadable binaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,56 @@ jobs:
             ConfuserEx.zip
             Confuser.MSBuild.Tasks/bin/Release/*.nupkg
 
+  # Pre-release: on push to pre-release branch
+  pre-release:
+    needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/pre-release'
+    runs-on: windows-2022
+    timeout-minutes: 5
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Install nbgv
+        run: dotnet tool install -g nbgv
+
+      - name: Compute version
+        id: version
+        shell: pwsh
+        run: |
+          $ver = nbgv get-version -v NuGetPackageVersion
+          echo "VERSION=$ver" >> $env:GITHUB_OUTPUT
+          Write-Host "Pre-release version: $ver"
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v5
+        with:
+          name: confuserex-packages
+
+      - name: Create or update pre-release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: pre-release
+          name: "Pre-release v${{ steps.version.outputs.VERSION }}"
+          prerelease: true
+          make_latest: false
+          body: |
+            **Pre-release build** — for testing only, not production use.
+
+            Version: `${{ steps.version.outputs.VERSION }}`
+            Branch: `pre-release`
+            Commit: ${{ github.sha }}
+
+            Download the binaries below to test recent fixes and features before they are included in a stable release.
+          files: |
+            ConfuserEx-CLI.zip
+            ConfuserEx-GUI.zip
+            ConfuserEx.zip
+            *.nupkg
+
   # Release: only on PR merge to master
   release:
     needs: build


### PR DESCRIPTION
## Summary
Adds automatic pre-release GitHub Releases when code is merged to the `pre-release` branch.

## How it works
- **`pre-release` branch push**: Creates/updates a GitHub Release tagged `pre-release` with `prerelease: true`
  - Uses a rolling tag — each merge overwrites the previous pre-release
  - Includes version, commit SHA, and download links in the body
  - Marked as pre-release (not shown as "latest")
- **`master` branch push**: Creates a stable versioned release (existing behavior, unchanged)

## Why
Testers can now download pre-built binaries from the Releases page to test fixes without building from source. When we ask upstream reporters to test (e.g., "try PR #60"), they can grab the pre-release build directly.

## Release page will show
- **Latest**: stable release from master
- **Pre-release**: latest pre-release build with all accumulated fixes