### PR TITLE
feat(analyzers): custom Roslyn analyzers CX001-CX004 with violation fixes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -63,6 +63,7 @@ dotnet_diagnostic.CA2227.severity = none          # Collection properties should
 
 # Roslynator severity overrides
 dotnet_diagnostic.RCS1018.severity = none          # Add accessibility modifiers (conflicts with existing style)
+dotnet_diagnostic.RCS1102.severity = none          # Make class static (many are non-static for runtime injection)
 dotnet_diagnostic.RCS1037.severity = none          # Remove trailing white-space
 dotnet_diagnostic.RCS1057.severity = none          # Add empty line between declarations
 dotnet_diagnostic.RCS1085.severity = none          # Use auto-implemented property

--- a/.editorconfig
+++ b/.editorconfig
@@ -61,6 +61,21 @@ dotnet_diagnostic.CA2000.severity = suggestion    # Dispose objects before losin
 dotnet_diagnostic.CA2007.severity = none          # ConfigureAwait (not needed for desktop app)
 dotnet_diagnostic.CA2227.severity = none          # Collection properties should be read only
 
+# Roslynator severity overrides
+dotnet_diagnostic.RCS1018.severity = none          # Add accessibility modifiers (conflicts with existing style)
+dotnet_diagnostic.RCS1037.severity = none          # Remove trailing white-space
+dotnet_diagnostic.RCS1057.severity = none          # Add empty line between declarations
+dotnet_diagnostic.RCS1085.severity = none          # Use auto-implemented property
+dotnet_diagnostic.RCS1090.severity = none          # ConfigureAwait
+dotnet_diagnostic.RCS1118.severity = none          # Mark local variable as const
+dotnet_diagnostic.RCS1124.severity = none          # Inline local variable
+dotnet_diagnostic.RCS1138.severity = none          # Add summary to documentation comment
+dotnet_diagnostic.RCS1139.severity = none          # Add summary element to documentation comment
+dotnet_diagnostic.RCS1163.severity = none          # Unused parameter
+dotnet_diagnostic.RCS1194.severity = none          # Implement exception constructors
+dotnet_diagnostic.RCS1213.severity = none          # Remove unused member declaration (too aggressive)
+dotnet_diagnostic.RCS1228.severity = none          # Unused element in documentation comment
+
 csharp_indent_block_contents = true
 csharp_indent_braces = false
 csharp_indent_case_contents = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -39,6 +39,28 @@ dotnet_style_qualification_for_property = false:suggestion
 dotnet_style_require_accessibility_modifiers = never:info
 
 [*.cs]
+# .NET Analyzer severity overrides
+dotnet_diagnostic.CA1002.severity = none          # Do not expose generic lists (too restrictive for internal code)
+dotnet_diagnostic.CA1031.severity = none          # Do not catch general exceptions (too many existing catch blocks)
+dotnet_diagnostic.CA1032.severity = none          # Implement standard exception constructors
+dotnet_diagnostic.CA1034.severity = none          # Nested types should not be visible
+dotnet_diagnostic.CA1062.severity = none          # Validate arguments of public methods (too noisy initially)
+dotnet_diagnostic.CA1303.severity = none          # Do not pass literals as localized parameters
+dotnet_diagnostic.CA1304.severity = none          # Specify CultureInfo
+dotnet_diagnostic.CA1305.severity = none          # Specify IFormatProvider
+dotnet_diagnostic.CA1307.severity = none          # Specify StringComparison for clarity
+dotnet_diagnostic.CA1310.severity = none          # Specify StringComparison for correctness
+dotnet_diagnostic.CA1707.severity = none          # Identifiers should not contain underscores (test naming)
+dotnet_diagnostic.CA1710.severity = none          # Identifiers should have correct suffix
+dotnet_diagnostic.CA1711.severity = none          # Identifiers should not have incorrect suffix
+dotnet_diagnostic.CA1720.severity = none          # Identifiers should not contain type names
+dotnet_diagnostic.CA1822.severity = suggestion    # Mark members as static (informational only)
+dotnet_diagnostic.CA1825.severity = warning       # Avoid zero-length array allocations
+dotnet_diagnostic.CA1859.severity = suggestion    # Use concrete types for improved performance
+dotnet_diagnostic.CA2000.severity = suggestion    # Dispose objects before losing scope
+dotnet_diagnostic.CA2007.severity = none          # ConfigureAwait (not needed for desktop app)
+dotnet_diagnostic.CA2227.severity = none          # Collection properties should be read only
+
 csharp_indent_block_contents = true
 csharp_indent_braces = false
 csharp_indent_case_contents = true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: ci
 
 on:
   push:
-    branches: [master, feature/**, fix/**]
+    branches: [master, pre-release, feature/**, fix/**]
   pull_request:
-    branches: [master]
+    branches: [master, pre-release]
 
 jobs:
   build:

--- a/Confuser.Analyzers/Confuser.Analyzers.csproj
+++ b/Confuser.Analyzers/Confuser.Analyzers.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>7.3</LangVersion>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <IsRoslynComponent>true</IsRoslynComponent>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.3.1" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all" />
+  </ItemGroup>
+
+</Project>

--- a/Confuser.Analyzers/ConfuserAnalyzers.cs
+++ b/Confuser.Analyzers/ConfuserAnalyzers.cs
@@ -1,0 +1,221 @@
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Confuser.Analyzers {
+	/// <summary>
+	///     CX003: Flags usage of ResolveThrow/ResolveTypeDefThrow/ResolveMethodDefThrow.
+	///     These throw on resolution failure instead of returning null — audit for intentionality.
+	/// </summary>
+	[DiagnosticAnalyzer(LanguageNames.CSharp)]
+	public sealed class ResolveThrowAuditAnalyzer : DiagnosticAnalyzer {
+		public const string DiagnosticId = "CX003";
+
+		static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+			DiagnosticId,
+			"ResolveThrow usage — consider non-throwing variant",
+			"'{0}' throws on resolution failure. Consider using the non-throwing variant with a null check.",
+			"Confuser.Reliability",
+			DiagnosticSeverity.Info,
+			isEnabledByDefault: true);
+
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+		static readonly string[] ThrowMethodNames = {
+			"ResolveThrow", "ResolveTypeDefThrow", "ResolveMethodDefThrow"
+		};
+
+		public override void Initialize(AnalysisContext context) {
+			context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+			context.EnableConcurrentExecution();
+			context.RegisterOperationAction(AnalyzeInvocation, OperationKind.Invocation);
+		}
+
+		void AnalyzeInvocation(OperationAnalysisContext context) {
+			var invocation = (IInvocationOperation)context.Operation;
+			var methodName = invocation.TargetMethod.Name;
+			if (ThrowMethodNames.Contains(methodName)) {
+				context.ReportDiagnostic(Diagnostic.Create(Rule, invocation.Syntax.GetLocation(), methodName));
+			}
+		}
+	}
+
+	/// <summary>
+	///     CX001: Detects typeof(X).GetMethod() passed to module.Import() — imports from host runtime
+	///     instead of the target assembly's framework version.
+	/// </summary>
+	[DiagnosticAnalyzer(LanguageNames.CSharp)]
+	public sealed class TypeofImportAnalyzer : DiagnosticAnalyzer {
+		public const string DiagnosticId = "CX001";
+
+		static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+			DiagnosticId,
+			"typeof().GetMethod() with module.Import() uses host runtime",
+			"Importing '{0}' via typeof() reflection resolves from the host runtime, not the target assembly's framework. Use dnlib type resolution instead.",
+			"Confuser.Correctness",
+			DiagnosticSeverity.Error,
+			isEnabledByDefault: true);
+
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+		public override void Initialize(AnalysisContext context) {
+			context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+			context.EnableConcurrentExecution();
+			context.RegisterOperationAction(AnalyzeInvocation, OperationKind.Invocation);
+		}
+
+		void AnalyzeInvocation(OperationAnalysisContext context) {
+			var invocation = (IInvocationOperation)context.Operation;
+			if (invocation.TargetMethod.Name != "Import")
+				return;
+
+			// Check if any argument contains typeof(...).GetMethod(...)
+			foreach (var arg in invocation.Arguments) {
+				if (IsTypeofGetMethodPattern(arg.Value))
+					context.ReportDiagnostic(Diagnostic.Create(Rule, invocation.Syntax.GetLocation(),
+						invocation.TargetMethod.ToDisplayString()));
+			}
+		}
+
+		static bool IsTypeofGetMethodPattern(IOperation operation) {
+			// Unwrap conversions
+			while (operation is IConversionOperation conv)
+				operation = conv.Operand;
+
+			if (operation is IInvocationOperation innerCall) {
+				var name = innerCall.TargetMethod.Name;
+				if (name == "GetMethod" || name == "GetField" || name == "GetProperty") {
+					// Check if receiver is typeof(...)
+					var receiver = innerCall.Instance;
+					if (receiver is ITypeOfOperation)
+						return true;
+					// typeof() result may be stored in variable — check arguments
+					foreach (var arg in innerCall.Arguments) {
+						if (arg.Value is ITypeOfOperation)
+							return true;
+					}
+				}
+			}
+			return false;
+		}
+	}
+
+	/// <summary>
+	///     CX004: Detects System.Reflection Assembly.GetTypes()/Module.GetTypes() calls
+	///     not wrapped in a try-catch for ReflectionTypeLoadException.
+	/// </summary>
+	[DiagnosticAnalyzer(LanguageNames.CSharp)]
+	public sealed class GetTypesWithoutCatchAnalyzer : DiagnosticAnalyzer {
+		public const string DiagnosticId = "CX004";
+
+		static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+			DiagnosticId,
+			"GetTypes() without ReflectionTypeLoadException catch",
+			"'{0}' can throw ReflectionTypeLoadException when types have unresolvable dependencies. Wrap in try-catch.",
+			"Confuser.Reliability",
+			DiagnosticSeverity.Warning,
+			isEnabledByDefault: true);
+
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+		public override void Initialize(AnalysisContext context) {
+			context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+			context.EnableConcurrentExecution();
+			context.RegisterOperationAction(AnalyzeInvocation, OperationKind.Invocation);
+		}
+
+		void AnalyzeInvocation(OperationAnalysisContext context) {
+			var invocation = (IInvocationOperation)context.Operation;
+			if (invocation.TargetMethod.Name != "GetTypes")
+				return;
+
+			// Only flag System.Reflection types, not dnlib
+			var containingType = invocation.TargetMethod.ContainingType?.ToString();
+			if (containingType == null)
+				return;
+			if (!containingType.StartsWith("System.Reflection."))
+				return;
+
+			// Check if inside a try-catch that handles ReflectionTypeLoadException
+			if (IsInsideCatchingTry(invocation.Syntax))
+				return;
+
+			context.ReportDiagnostic(Diagnostic.Create(Rule, invocation.Syntax.GetLocation(), containingType + ".GetTypes()"));
+		}
+
+		static bool IsInsideCatchingTry(SyntaxNode node) {
+			var current = node.Parent;
+			while (current != null) {
+				if (current is TryStatementSyntax trySyntax) {
+					foreach (var catchClause in trySyntax.Catches) {
+						var typeName = catchClause.Declaration?.Type?.ToString();
+						if (typeName == null) // bare catch
+							return true;
+						if (typeName.Contains("ReflectionTypeLoadException") || typeName == "Exception")
+							return true;
+					}
+				}
+				current = current.Parent;
+			}
+			return false;
+		}
+	}
+
+	/// <summary>
+	///     CX002: Detects ResolveTypeDef()/ResolveMethodDef() calls where the result
+	///     is used without a null check.
+	/// </summary>
+	[DiagnosticAnalyzer(LanguageNames.CSharp)]
+	public sealed class ResolveWithoutNullCheckAnalyzer : DiagnosticAnalyzer {
+		public const string DiagnosticId = "CX002";
+
+		static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+			DiagnosticId,
+			"Resolve result used without null check",
+			"'{0}' can return null when resolution fails. Check for null before use.",
+			"Confuser.Reliability",
+			DiagnosticSeverity.Warning,
+			isEnabledByDefault: true);
+
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+		static readonly string[] ResolveMethodNames = {
+			"ResolveTypeDef", "ResolveMethodDef"
+		};
+
+		public override void Initialize(AnalysisContext context) {
+			context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+			context.EnableConcurrentExecution();
+			context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
+		}
+
+		void AnalyzeInvocation(SyntaxNodeAnalysisContext context) {
+			var invocation = (InvocationExpressionSyntax)context.Node;
+			var memberAccess = invocation.Expression as MemberAccessExpressionSyntax;
+			if (memberAccess == null)
+				return;
+
+			var methodName = memberAccess.Name.Identifier.Text;
+			if (!ResolveMethodNames.Contains(methodName))
+				return;
+
+			// Check if the result is immediately accessed without null check
+			var parent = invocation.Parent;
+
+			// Pattern: foo.ResolveTypeDef().Something — direct member access on result
+			if (parent is MemberAccessExpressionSyntax outerAccess && outerAccess.Expression == invocation) {
+				// Check if it's ?. (null-conditional)
+				if (!(parent.Parent is ConditionalAccessExpressionSyntax))
+					context.ReportDiagnostic(Diagnostic.Create(Rule, invocation.GetLocation(), methodName));
+			}
+
+			// Pattern: var x = foo.ResolveTypeDef(); — check if assigned and used without null check
+			// This is complex data-flow analysis; for now, only flag direct member access chains.
+			// The while-loop pattern (where null terminates iteration) is safe and not flagged.
+		}
+	}
+}

--- a/Confuser.CLI/Program.cs
+++ b/Confuser.CLI/Program.cs
@@ -60,10 +60,8 @@ namespace Confuser.CLI {
 					try {
 						var xmlDoc = new XmlDocument();
 						xmlDoc.Load(files[0]);
-						proj.Load(xmlDoc);
-						string crprojDir = Path.GetDirectoryName(Path.GetFullPath(files[0]));
-						proj.BaseDirectory = Path.GetFullPath(Path.Combine(crprojDir, proj.BaseDirectory));
-						proj.OutputDirectory = Path.GetFullPath(Path.Combine(crprojDir, proj.OutputDirectory));
+						proj.Load(xmlDoc, Path.GetDirectoryName(Path.GetFullPath(files[0])));
+						proj.OutputDirectory = Path.GetFullPath(Path.Combine(proj.BaseDirectory, proj.OutputDirectory));
 					}
 					catch (Exception ex) {
 						WriteLineWithColor(ConsoleColor.Red, "Failed to load project:");

--- a/Confuser.CLI/Program.cs
+++ b/Confuser.CLI/Program.cs
@@ -19,6 +19,8 @@ namespace Confuser.CLI {
 				bool noPause = false;
 				bool debug = false;
 				string outDir = null;
+				string snKeyPath = null;
+				string snKeyPass = null;
 				List<string> probePaths = new List<string>();
 				List<string> plugins = new List<string>();
 				var p = new OptionSet {
@@ -37,6 +39,12 @@ namespace Confuser.CLI {
 					}, {
 						"debug", "specifies debug symbol generation.",
 						value => { debug = (value != null); }
+					}, {
+						"snkey=", "specifies strong name key file path.",
+						value => { snKeyPath = value; }
+					}, {
+						"snkeypass=", "specifies strong name key password.",
+						value => { snKeyPass = value; }
 					}
 				};
 
@@ -101,10 +109,13 @@ namespace Confuser.CLI {
 							modulePath = modulePath.Substring(proj.BaseDirectory.Length + 1);
 						}
 
-						if (TryMatchTemplateProject(templateModules, proj.BaseDirectory, modulePath, out var matchedModule))
+						if (TryMatchTemplateProject(templateModules, proj.BaseDirectory, modulePath, out var matchedModule)) {
+							if (snKeyPath != null) matchedModule.SNKeyPath = snKeyPath;
+							if (snKeyPass != null) matchedModule.SNKeyPassword = snKeyPass;
 							proj.Add(matchedModule);
+						}
 						else
-							proj.Add(new ProjectModule { Path = modulePath });
+							proj.Add(new ProjectModule { Path = modulePath, SNKeyPath = snKeyPath, SNKeyPassword = snKeyPass });
 					}
 
 					proj.OutputDirectory = outDir;
@@ -200,6 +211,8 @@ namespace Confuser.CLI {
 			WriteLine("    -probe     : specifies probe directory.");
 			WriteLine("    -plugin    : specifies plugin path.");
 			WriteLine("    -debug     : specifies debug symbol generation.");
+			WriteLine("    -snkey     : specifies strong name key file path.");
+			WriteLine("    -snkeypass : specifies strong name key password.");
 		}
 
 		static void WriteLineWithColor(ConsoleColor color, string txt) {

--- a/Confuser.Core/ConfuserAssemblyResolver.cs
+++ b/Confuser.Core/ConfuserAssemblyResolver.cs
@@ -33,8 +33,50 @@ namespace Confuser.Core {
 			if (assembly is AssemblyDef assemblyDef)
 				return assemblyDef;
 
-			var resolvedAssemblyDef = InternalExactResolver.Resolve(assembly, sourceModule);
-			return resolvedAssemblyDef ?? InternalFuzzyResolver.Resolve(assembly, sourceModule);
+			var resolvedAssemblyDef =
+				InternalExactResolver.Resolve(assembly, sourceModule) ??
+				InternalFuzzyResolver.Resolve(assembly, sourceModule);
+
+			//	Remove AssemblyAttributes.PA_NoPlatform
+			if (null != resolvedAssemblyDef &&
+				(AssemblyAttributes.PA_Mask & resolvedAssemblyDef.Attributes) == AssemblyAttributes.PA_NoPlatform) {
+				resolvedAssemblyDef.Attributes =
+					resolvedAssemblyDef.Attributes & ~AssemblyAttributes.PA_FullMask;
+			}
+
+			if (resolvedAssemblyDef?.Name == "netstandard" && 0 < resolvedAssemblyDef.ManifestModule.ExportedTypes.Count) {
+				//	Move types from AssemblyRef to here
+				var module = resolvedAssemblyDef.ManifestModule;
+				var newTypes = new List<TypeDef>();
+				var allAssemblyRefs = new List<AssemblyDef>();
+
+				module.ExportedTypes.Clear();
+
+				foreach (var assemblyRef in module.GetAssemblyRefs()) {
+					var subAss =
+						InternalExactResolver.Resolve(assemblyRef, module) ??
+						InternalFuzzyResolver.Resolve(assemblyRef, module);
+					allAssemblyRefs.Add(subAss);
+					foreach (var subModule in subAss?.Modules) {
+						foreach (var defType in subModule.Types) {
+							newTypes.Add(defType);
+						}
+						subModule.Types.Clear();
+						foreach (var defType in newTypes) {
+							module.Types.Add(defType);
+						}
+						newTypes.Clear();
+					}
+				}
+
+				//	Remove them because their types has been removed.
+				foreach (var subAss in allAssemblyRefs) {
+					InternalExactResolver.Remove(subAss);
+					InternalFuzzyResolver.Remove(subAss);
+				}
+			}
+
+			return resolvedAssemblyDef;
 		}
 
 		public void Clear() {

--- a/Confuser.Core/ConfuserEngine.cs
+++ b/Confuser.Core/ConfuserEngine.cs
@@ -263,13 +263,10 @@ namespace Confuser.Core {
 			context.Logger.Info("Resolving dependencies...");
 			foreach (var dependency in context.Modules
 											  .SelectMany(module => module.GetAssemblyRefs().Select(asmRef => Tuple.Create(asmRef, module)))) {
-				try {
-					context.Resolver.ResolveThrow(dependency.Item1, dependency.Item2);
-				}
-				catch (AssemblyResolveException ex) {
-					context.Logger.ErrorException("Failed to resolve dependency of '" + dependency.Item2.Name + "'.", ex);
-					throw new ConfuserException(ex);
-				}
+				var resolved = context.Resolver.Resolve(dependency.Item1, dependency.Item2);
+				if (resolved == null)
+					context.Logger.WarnFormat("Failed to resolve dependency '{0}' of '{1}'. Some protections may not work correctly.",
+						dependency.Item1.FullName, dependency.Item2.Name);
 			}
 
 			context.Logger.Debug("Checking Strong Name...");

--- a/Confuser.Core/ConfuserEngine.cs
+++ b/Confuser.Core/ConfuserEngine.cs
@@ -421,6 +421,8 @@ namespace Confuser.Core {
 
 		static void Debug(ConfuserContext context) {
 			context.Logger.Info("Finalizing...");
+			if (!context.Project.Debug)
+				return;
 			for (int i = 0; i < context.OutputModules.Count; i++) {
 				if (context.OutputSymbols[i] == null)
 					continue;

--- a/Confuser.Core/DnlibUtils.cs
+++ b/Confuser.Core/DnlibUtils.cs
@@ -209,15 +209,12 @@ namespace Confuser.Core {
 		/// <param name="baseType">The full name of base type.</param>
 		/// <returns><c>true</c> if the specified type is inherited from a base type; otherwise, <c>false</c>.</returns>
 		public static bool InheritsFromCorlib(this TypeDef type, string baseType) {
-			if (type.BaseType == null)
-				return false;
-
-			TypeDef bas = type;
-			do {
-				bas = bas.BaseType.ResolveTypeDefThrow();
+			var bas = type.BaseType?.ResolveTypeDef();
+			while (bas != null && bas.DefinitionAssembly.IsCorLib()) {
 				if (bas.ReflectionFullName == baseType)
 					return true;
-			} while (bas.BaseType != null && bas.BaseType.DefinitionAssembly.IsCorLib());
+				bas = bas.BaseType?.ResolveTypeDef();
+			}
 			return false;
 		}
 
@@ -228,15 +225,12 @@ namespace Confuser.Core {
 		/// <param name="baseType">The full name of base type.</param>
 		/// <returns><c>true</c> if the specified type is inherited from a base type; otherwise, <c>false</c>.</returns>
 		public static bool InheritsFrom(this TypeDef type, string baseType) {
-			if (type.BaseType == null)
-				return false;
-
-			TypeDef bas = type;
-			do {
-				bas = bas.BaseType.ResolveTypeDefThrow();
+			var bas = type.BaseType?.ResolveTypeDef();
+			while (bas != null) {
 				if (bas.ReflectionFullName == baseType)
 					return true;
-			} while (bas.BaseType != null);
+				bas = bas.BaseType?.ResolveTypeDef();
+			}
 			return false;
 		}
 
@@ -247,18 +241,12 @@ namespace Confuser.Core {
 		/// <param name="fullName">The full name of the type of interface.</param>
 		/// <returns><c>true</c> if the specified type implements the interface; otherwise, <c>false</c>.</returns>
 		public static bool Implements(this TypeDef type, string fullName) {
-			do {
-				foreach (InterfaceImpl iface in type.Interfaces) {
-					if (iface.Interface.ReflectionFullName == fullName)
-						return true;
-				}
-
-				if (type.BaseType == null)
-					return false;
-
-				type = type.BaseType.ResolveTypeDefThrow();
-			} while (type != null);
-			throw new UnreachableException();
+			while (type != null) {
+				if (type.Interfaces.Any(iface => iface.Interface.ReflectionFullName == fullName))
+					return true;
+				type = type.BaseType?.ResolveTypeDef();
+			}
+			return false;
 		}
 
 		/// <summary>
@@ -451,8 +439,8 @@ namespace Confuser.Core {
 
 			if (method.IsPublic && method.IsNewSlot) {
 				foreach (var iFace in method.DeclaringType.Interfaces) {
-					var iFaceDef = iFace.Interface.ResolveTypeDefThrow();
-					if (iFaceDef.FindMethod(method.Name, (MethodSig)method.Signature) != null)
+					var iFaceDef = iFace.Interface.ResolveTypeDef();
+					if (iFaceDef != null && iFaceDef.FindMethod(method.Name, (MethodSig)method.Signature) != null)
 						return true;
 				}
 			}

--- a/Confuser.Core/ObfAttrMarker.cs
+++ b/Confuser.Core/ObfAttrMarker.cs
@@ -326,6 +326,14 @@ namespace Confuser.Core {
 				}
 				catch (BadImageFormatException ex) {
 					context.Logger.ErrorFormat("Failed to load \"{0}\" - Assembly does not appear to be a .NET assembly: \"{1}\".", module.Path, ex.Message);
+					if (module.Path.EndsWith(".exe", StringComparison.OrdinalIgnoreCase)) {
+						var dllPath = Path.ChangeExtension(module.Path, ".dll");
+						var fullDllPath = Path.Combine(proj.BaseDirectory, dllPath);
+						if (File.Exists(fullDllPath))
+							context.Logger.ErrorFormat("Hint: .NET 6+ apps use a native host .exe — try obfuscating \"{0}\" instead.", dllPath);
+						else
+							context.Logger.Error("Hint: For .NET 6+ apps, obfuscate the .dll file, not the .exe (which is a native host stub).");
+					}
 					throw new ConfuserException(ex);
 				}
 			}

--- a/Confuser.Core/PluginDiscovery.cs
+++ b/Confuser.Core/PluginDiscovery.cs
@@ -54,8 +54,11 @@ namespace Confuser.Core {
 		protected static void AddPlugins(
 			ConfuserContext context, IList<Protection> protections, IList<Packer> packers,
 			IList<ConfuserComponent> components, Assembly asm) {
-			foreach(var module in asm.GetLoadedModules())
-				foreach (var i in module.GetTypes()) {
+			foreach (var module in asm.GetLoadedModules()) {
+				Type[] types;
+				try { types = module.GetTypes(); }
+				catch (System.Reflection.ReflectionTypeLoadException ex) { types = ex.Types.Where(t => t != null).ToArray(); }
+				foreach (var i in types) {
 					if (i.IsAbstract || !HasAccessibleDefConstructor(i))
 						continue;
 
@@ -83,6 +86,7 @@ namespace Confuser.Core {
 							context.Logger.ErrorException("Failed to instantiate component '" + i.Name + "'.", ex);
 						}
 					}
+				}
 				}
 			context.CheckCancellation();
 		}

--- a/Confuser.Core/PluginDiscovery.cs
+++ b/Confuser.Core/PluginDiscovery.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 
 namespace Confuser.Core {

--- a/Confuser.Core/Project/ConfuserProject.cs
+++ b/Confuser.Core/Project/ConfuserProject.cs
@@ -626,7 +626,7 @@ namespace Confuser.Core.Project {
 		/// <exception cref="Confuser.Core.Project.ProjectValidationException">
 		///     The project XML contains schema errors.
 		/// </exception>
-		public void Load(XmlDocument doc) {
+		public void Load(XmlDocument doc, string baseDirRoot = null) {
 			doc.Schemas.Add(Schema);
 			var exceptions = new List<XmlSchemaException>();
 			doc.Validate((sender, e) => {
@@ -641,6 +641,10 @@ namespace Confuser.Core.Project {
 
 			OutputDirectory = docElem.Attributes["outputDir"].Value;
 			BaseDirectory = docElem.Attributes["baseDir"].Value;
+			if (!string.IsNullOrEmpty(baseDirRoot))
+			{
+				BaseDirectory = Path.Combine(baseDirRoot, BaseDirectory);
+			}
 
 			if (docElem.Attributes["seed"] != null)
 				Seed = docElem.Attributes["seed"].Value.NullIfEmpty();
@@ -674,11 +678,44 @@ namespace Confuser.Core.Project {
 					PluginPaths.Add(i.InnerText);
 				}
 				else {
-					var asm = new ProjectModule();
-					asm.Load(i);
-					Add(asm);
+					AddModule(i);
 				}
 			}
+		}
+
+		internal void AddModule(XmlElement elem) {
+			if (IsWildcard(elem.Attributes["path"].Value)) {
+				BatchLoadModules(elem);
+			}
+			else {
+				var asm = new ProjectModule();
+				asm.Load(elem);
+				Add(asm);
+			}
+		}
+
+		internal bool IsWildcard(string path) {
+			return !string.IsNullOrEmpty(path) && path.Contains(@"*");
+		}
+
+		internal bool BatchLoadModules(XmlElement elem) {
+			string wildCardPath = elem.Attributes["path"].Value;
+			string[] files = Directory.GetFiles(BaseDirectory, wildCardPath, SearchOption.TopDirectoryOnly);
+			if (files.Length <= 0)
+			{
+				return false;
+			}
+
+			var asmPrototype = new ProjectModule();
+			asmPrototype.Load(elem);
+
+			foreach (string fileName in files) {
+				var moduleEntry = asmPrototype.Clone();
+				moduleEntry.Path = fileName;
+				Add(moduleEntry);
+			}
+
+			return true;
 		}
 
 		/// <summary>

--- a/Confuser.Core/ProtectionParameters.cs
+++ b/Confuser.Core/ProtectionParameters.cs
@@ -14,7 +14,7 @@ namespace Confuser.Core {
 		/// <summary>
 		///     A empty instance of <see cref="ProtectionParameters" />.
 		/// </summary>
-		public static readonly ProtectionParameters Empty = new ProtectionParameters(null, new IDnlibDef[0]);
+		public static readonly ProtectionParameters Empty = new ProtectionParameters(null, Array.Empty<IDnlibDef>());
 
 		readonly ConfuserComponent comp;
 

--- a/Confuser.Core/Services/TraceService.cs
+++ b/Confuser.Core/Services/TraceService.cs
@@ -204,7 +204,7 @@ namespace Confuser.Core.Services {
 		public int[] TraceArguments(Instruction instr) {
 			instr.CalculateStackUsage(Method.HasReturnType, out _, out int pop); // pop is number of arguments
 			if (pop == 0)
-				return new int[0];
+				return Array.Empty<int>();
 
 			int instrIndex = offset2index[instr.Offset];
 			int argCount = pop;

--- a/Confuser.Protections/AntiTamper/JITBody.cs
+++ b/Confuser.Protections/AntiTamper/JITBody.cs
@@ -134,7 +134,7 @@ namespace Confuser.Protections.AntiTamper {
 				jitBody.LocalVars = SignatureWriter.Write(metadata, local);
 			}
 			else
-				jitBody.LocalVars = new byte[0];
+				jitBody.LocalVars = Array.Empty<byte>();
 
       {
         var newCode = new byte[codeSize];

--- a/Confuser.Protections/Compress/Compressor.cs
+++ b/Confuser.Protections/Compress/Compressor.cs
@@ -175,7 +175,7 @@ namespace Confuser.Protections {
 			context.Logger.EndProgress();
 		}
 
-		void InjectData(ModuleDef stubModule, MethodDef method, byte[] data) {
+		void InjectData(ConfuserContext context, ModuleDef stubModule, MethodDef method, byte[] data) {
 			var dataType = new TypeDefUser("", "DataType", stubModule.CorLibTypes.GetTypeRef("System", "ValueType"));
 			dataType.Layout = TypeAttributes.ExplicitLayout;
 			dataType.Visibility = TypeAttributes.NestedPrivate;
@@ -197,7 +197,7 @@ namespace Confuser.Protections {
 				repl.Add(Instruction.Create(OpCodes.Dup));
 				repl.Add(Instruction.Create(OpCodes.Ldtoken, dataField));
 				repl.Add(Instruction.Create(OpCodes.Call, stubModule.Import(
-					typeof(RuntimeHelpers).GetMethod("InitializeArray"))));
+					context, typeof(RuntimeHelpers), "InitializeArray")));
 				return repl.ToArray();
 			});
 		}
@@ -254,7 +254,7 @@ namespace Confuser.Protections {
 			MutationHelper.InjectKeys(entryPoint,
 									  new[] { 0, 1 },
 									  new[] { encryptedModule.Length >> 2, (int)seed });
-			InjectData(stubModule, entryPoint, encryptedModule);
+			InjectData(context, stubModule, entryPoint, encryptedModule);
 
 			// Decrypt
 			MethodDef decrypter = defs.OfType<MethodDef>().Single(method => method.Name == "Decrypt");

--- a/Confuser.Protections/Constants/EncodePhase.cs
+++ b/Confuser.Protections/Constants/EncodePhase.cs
@@ -122,7 +122,7 @@ namespace Confuser.Protections.Constants {
 				repl.Add(Instruction.Create(OpCodes.Dup));
 				repl.Add(Instruction.Create(OpCodes.Ldtoken, moduleCtx.DataField));
 				repl.Add(Instruction.Create(OpCodes.Call, moduleCtx.Module.Import(
-					typeof(RuntimeHelpers).GetMethod("InitializeArray"))));
+					context, typeof(RuntimeHelpers), "InitializeArray")));
 				return repl.ToArray();
 			});
 		}

--- a/Confuser.Protections/ControlFlow/SwitchMangler.cs
+++ b/Confuser.Protections/ControlFlow/SwitchMangler.cs
@@ -260,16 +260,8 @@ namespace Confuser.Protections.ControlFlow {
 						                    src.Offset >= block.Instructions.Last().Offset))
 							return true;
 
-						// Disable flow obfuscation for blocks reached by jump instructions.
-						// Bug in #153 caused exactly this behaviour, expect for allowing wrong jump instructions
-						// There is another issue present here tracked here:
-						// https://github.com/mkaring/ConfuserEx/issues/162
-						// Until this issue is resolved, the ctrl flow obfuscation will be severely reduced.
-						if (srcs.Any())
-							return true;
-
 						// Not targeted by the last of statements
-						if (srcs.Any(src => !statementLast.Contains(src)))
+						if (srcs.Any(src => statementLast.Contains(src)))
 							return true;
 					}
 					return false;

--- a/Confuser.Protections/ReferenceProxy/MildMode.cs
+++ b/Confuser.Protections/ReferenceProxy/MildMode.cs
@@ -14,10 +14,12 @@ namespace Confuser.Protections.ReferenceProxy {
 			var target = (IMethod)invoke.Operand;
 
 			// Value type proxy is not supported in mild mode.
-			if (target.DeclaringType.ResolveTypeDefThrow().IsValueType)
+			var declaringTypeDef = target.DeclaringType.ResolveTypeDef();
+			if (declaringTypeDef == null || declaringTypeDef.IsValueType)
 				return;
 			// Skipping visibility is not supported in mild mode.
-			if (!target.ResolveThrow().IsPublic && !target.ResolveThrow().IsAssembly)
+			var targetMethodDef = (target as IMethodDefOrRef)?.ResolveMethodDef();
+			if (targetMethodDef == null || (!targetMethodDef.IsPublic && !targetMethodDef.IsAssembly))
 				return;
 
 			Tuple<Code, TypeDef, IMethod> key = Tuple.Create(invoke.OpCode.Code, ctx.Method.DeclaringType, target);
@@ -31,7 +33,7 @@ namespace Confuser.Protections.ReferenceProxy {
 				ctx.Method.DeclaringType.Methods.Add(proxy);
 
 				// Fix peverify --- Non-virtual call to virtual methods must be done on this pointer
-				if (invoke.OpCode.Code == Code.Call && target.ResolveThrow().IsVirtual) {
+				if (invoke.OpCode.Code == Code.Call && targetMethodDef != null && targetMethodDef.IsVirtual) {
 					proxy.IsStatic = false;
 					sig.HasThis = true;
 					sig.Params.RemoveAt(0);
@@ -65,9 +67,8 @@ namespace Confuser.Protections.ReferenceProxy {
 			else
 				invoke.Operand = proxy;
 
-			var targetDef = target.ResolveMethodDef();
-			if (targetDef != null)
-				ctx.Context.Annotations.Set(targetDef, ReferenceProxyProtection.Targeted, ReferenceProxyProtection.Targeted);
+			if (targetMethodDef != null)
+				ctx.Context.Annotations.Set(targetMethodDef, ReferenceProxyProtection.Targeted, ReferenceProxyProtection.Targeted);
 		}
 
 		public override void Finalize(RPContext ctx) { }

--- a/Confuser.Protections/ReferenceProxy/ReferenceProxyPhase.cs
+++ b/Confuser.Protections/ReferenceProxy/ReferenceProxyPhase.cs
@@ -147,7 +147,9 @@ namespace Confuser.Protections.ReferenceProxy {
 					if (operand.MethodSig.ParamsAfterSentinel != null &&
 						operand.MethodSig.ParamsAfterSentinel.Count > 0)
 						continue;
-					TypeDef declType = operand.DeclaringType.ResolveTypeDefThrow();
+					TypeDef declType = operand.DeclaringType.ResolveTypeDef();
+					if (declType == null)
+						continue;
 					// No delegates
 					if (declType.IsDelegate())
 						continue;

--- a/Confuser.Protections/Resources/InjectPhase.cs
+++ b/Confuser.Protections/Resources/InjectPhase.cs
@@ -137,7 +137,7 @@ namespace Confuser.Protections.Resources {
 				repl.Add(Instruction.Create(OpCodes.Dup));
 				repl.Add(Instruction.Create(OpCodes.Ldtoken, moduleCtx.DataField));
 				repl.Add(Instruction.Create(OpCodes.Call, moduleCtx.Module.Import(
-					typeof(RuntimeHelpers).GetMethod("InitializeArray"))));
+					moduleCtx.Context, typeof(RuntimeHelpers), "InitializeArray")));
 				return repl.ToArray();
 			});
 			moduleCtx.Context.Registry.GetService<IConstantService>().ExcludeMethod(moduleCtx.Context, moduleCtx.InitMethod);

--- a/Confuser.Protections/Resources/InjectPhase.cs
+++ b/Confuser.Protections/Resources/InjectPhase.cs
@@ -97,7 +97,7 @@ namespace Confuser.Protections.Resources {
 			moduleCtx.DataField = new FieldDefUser(moduleCtx.Name.RandomName(), new FieldSig(dataType.ToTypeSig())) {
 				IsStatic = true,
 				HasFieldRVA = true,
-				InitialValue = new byte[0],
+				InitialValue = Array.Empty<byte>(),
 				Access = FieldAttributes.CompilerControlled
 			};
 			context.CurrentModule.GlobalType.Fields.Add(moduleCtx.DataField);

--- a/Confuser.Protections/Utils.cs
+++ b/Confuser.Protections/Utils.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+using Confuser.Core;
+using dnlib.DotNet;
+
+namespace Confuser.Protections {
+	internal static class Utils {
+		public static IMethod Import(this ModuleDef module, ConfuserContext context, Type classType, string method) {
+			var corLib = context.Resolver.Resolve(context.CurrentModule?.CorLibTypes.AssemblyRef, context.CurrentModule);
+			var typeInfo = corLib?.ManifestModule.Find(classType.FullName, true);
+			return (typeInfo == null) ? module.Import(classType.GetMethod(method)) : module.Import(typeInfo.FindMethod(method));
+		}
+	}
+}

--- a/Confuser.Renamer/AnalyzePhase.cs
+++ b/Confuser.Renamer/AnalyzePhase.cs
@@ -206,6 +206,10 @@ namespace Confuser.Renamer {
 			if (type.InheritsFrom("System.Configuration.SettingsBase")) {
 				service.SetCanRename(type, false);
 			}
+
+			if (type.HasAttribute("System.Runtime.Serialization.DataContractAttribute")) {
+				service.SetCanRename(type, false);
+			}
 		}
 
 		void Analyze(NameService service, ConfuserContext context, ProtectionParameters parameters, MethodDef method) {
@@ -248,6 +252,12 @@ namespace Confuser.Renamer {
 			else if (field.IsLiteral && field.DeclaringType.IsEnum &&
 				!parameters.GetParameter(context, field, "renEnum", false))
 				service.SetCanRename(field, false);
+
+			else if (field.HasAttribute("System.Runtime.Serialization.DataMemberAttribute"))
+				service.SetCanRename(field, false);
+
+			else if (field.HasAttribute("System.Runtime.Serialization.EnumMemberAttribute"))
+				service.SetCanRename(field, false);
 		}
 
 		void Analyze(NameService service, ConfuserContext context, ProtectionParameters parameters, PropertyDef property) {
@@ -266,6 +276,9 @@ namespace Confuser.Renamer {
 				service.SetCanRename(property, false);
 
 			else if (property.DeclaringType.Name.String.Contains("AnonymousType"))
+				service.SetCanRename(property, false);
+
+			else if (property.HasAttribute("System.Runtime.Serialization.DataMemberAttribute"))
 				service.SetCanRename(property, false);
 		}
 

--- a/Confuser.Renamer/Analyzers/VTableAnalyzer.cs
+++ b/Confuser.Renamer/Analyzers/VTableAnalyzer.cs
@@ -354,7 +354,7 @@ namespace Confuser.Renamer.Analyzers {
 
 			var targetDeclTypeDef = targetMethod.DeclaringType.ResolveTypeDef();
 			var overrideDeclTypeDef = methodOverride.MethodDeclaration.DeclaringType.ResolveTypeDef();
-			if (!comparer.Equals(targetDeclTypeDef, overrideDeclTypeDef))
+			if (targetDeclTypeDef == null || overrideDeclTypeDef == null || !comparer.Equals(targetDeclTypeDef, overrideDeclTypeDef))
 				return false;
 
 			var targetMethodSig = targetMethod.MethodSig;

--- a/Confuser.Renamer/Analyzers/WPFAnalyzer.cs
+++ b/Confuser.Renamer/Analyzers/WPFAnalyzer.cs
@@ -60,6 +60,10 @@ namespace Confuser.Renamer.Analyzers {
 					var decodedName = HttpUtility.UrlDecode(doc.DocumentName);
 					var encodedName = doc.DocumentName;
 					if (bamlRefs.TryGetValue(decodedName, out var references)) {
+						// WPF theme resources must keep their conventional paths
+						if (decodedName.IndexOf("themes/generic", StringComparison.OrdinalIgnoreCase) >= 0)
+							continue;
+
 						var decodedLastSlash = decodedName.LastIndexOf('/') + 1;
 						var encodedLastSlash = encodedName.LastIndexOf('/') + 1;
 

--- a/Confuser.Renamer/Analyzers/WPFAnalyzer.cs
+++ b/Confuser.Renamer/Analyzers/WPFAnalyzer.cs
@@ -60,8 +60,14 @@ namespace Confuser.Renamer.Analyzers {
 					var decodedName = HttpUtility.UrlDecode(doc.DocumentName);
 					var encodedName = doc.DocumentName;
 					if (bamlRefs.TryGetValue(decodedName, out var references)) {
-						var decodedDirectory = decodedName.Substring(0, decodedName.LastIndexOf('/') + 1);
-						var encodedDirectory = encodedName.Substring(0, encodedName.LastIndexOf('/') + 1);
+						var decodedLastSlash = decodedName.LastIndexOf('/') + 1;
+						var encodedLastSlash = encodedName.LastIndexOf('/') + 1;
+
+						var decodedDirectory = decodedName.Substring(0, decodedLastSlash);
+						var encodedDirectory = encodedName.Substring(0, encodedLastSlash);
+
+						var decodedFileName = decodedName.Substring(decodedLastSlash);
+						var encodedFileName = encodedName.Substring(encodedLastSlash);
 
 						var fileName = service.RandomName(renameMode).ToLowerInvariant();
 						if (decodedName.EndsWith(".BAML", StringComparison.OrdinalIgnoreCase))
@@ -78,8 +84,8 @@ namespace Confuser.Renamer.Analyzers {
 
 						if (renameOk) {
 							foreach (var bamlRef in references) {
-								bamlRef.Rename(module, decodedName, decodedNewName);
-								bamlRef.Rename(module, encodedName, encodedNewName);
+								bamlRef.Rename(module, decodedFileName, fileName);
+								bamlRef.Rename(module, encodedFileName, fileName);
 							}
 							doc.DocumentName = encodedNewName;
 						}

--- a/Confuser.Renamer/BAML/PropertyPath/PropertyPathParser.cs
+++ b/Confuser.Renamer/BAML/PropertyPath/PropertyPathParser.cs
@@ -317,7 +317,7 @@ namespace Confuser.Renamer.BAML {
 		ArrayList _al = new ArrayList();
 		const char NullChar = Char.MinValue;
 		const char EscapeChar = '^';
-		static SourceValueInfo[] EmptyInfo = new SourceValueInfo[0];
+		static SourceValueInfo[] EmptyInfo = Array.Empty<SourceValueInfo>();
 		static string SpecialChars = @"./[]";
 	}
 }

--- a/Confuser.Renamer/GenericArgumentResolver.cs
+++ b/Confuser.Renamer/GenericArgumentResolver.cs
@@ -122,7 +122,8 @@ namespace Confuser.Renamer {
 					result = new PinnedSig(ResolveGenericArgs(typeSig.Next));
 					break;
 				case ElementType.FnPtr:
-					throw new NotSupportedException("FnPtr is not supported.");
+					result = typeSig;
+					break;
 
 				case ElementType.Array:
 					var arraySig = (ArraySig)typeSig;

--- a/Confuser.Renamer/NameService.cs
+++ b/Confuser.Renamer/NameService.cs
@@ -214,7 +214,7 @@ namespace Confuser.Renamer {
 
 		public string ObfuscateName(string format, string name, RenameMode mode, bool preserveGenericParams = false) {
 			int genericParamsCount = 0;
-			if (preserveGenericParams) {
+			if (preserveGenericParams && !string.IsNullOrEmpty(name)) {
 				name = ParseGenericName(name, out genericParamsCount);
 			}
 

--- a/Confuser.Renamer/RenamePhase.cs
+++ b/Confuser.Renamer/RenamePhase.cs
@@ -36,8 +36,13 @@ namespace Confuser.Renamer {
 
 				if (def is MethodDef method) {
 					if ((canRename || method.IsConstructor) && parameters.GetParameter(context, method, "renameArgs", true)) {
-						foreach (var param in method.ParamDefs)
-							param.Name = null;
+						if (method.IsConstructor && method.DeclaringType.Name.String.Contains("AnonymousType")) {
+							// Anonymous type constructor args map to property names — renaming breaks JSON serialization
+						}
+						else {
+							foreach (var param in method.ParamDefs)
+								param.Name = null;
+						}
 					}
 
 					if (parameters.GetParameter(context, method, "renPdb", false) && method.HasBody) {

--- a/Confuser.Renamer/RenamePhase.cs
+++ b/Confuser.Renamer/RenamePhase.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Confuser.Core;
@@ -14,8 +15,12 @@ namespace Confuser.Renamer {
 
 		public override string Name => "Renaming";
 
+		// Tracks overload confusion name assignments: TypeDef -> list of assigned names
+		readonly Dictionary<TypeDef, List<string>> _overloadNames = new Dictionary<TypeDef, List<string>>();
+
 		protected override void Execute(ConfuserContext context, ProtectionParameters parameters) {
 			var service = (NameService)context.Registry.GetService<INameService>();
+			bool overloadConfusion = parameters.GetParameter(context, context.CurrentModule, "overload", false);
 
 			context.Logger.Debug("Renaming...");
 			foreach (var renamer in service.Renamers) {
@@ -84,7 +89,12 @@ namespace Confuser.Renamer {
 					RenameGenericParameters(typeDef.GenericParameters);
 				}
 				else if (def is MethodDef methodDef) {
-					methodDef.Name = service.ObfuscateName(methodDef, mode);
+					if (overloadConfusion && CanApplyOverloadConfusion(methodDef, service)) {
+						methodDef.Name = GetOverloadName(methodDef, service, mode);
+					}
+					else {
+						methodDef.Name = service.ObfuscateName(methodDef, mode);
+					}
 					RenameGenericParameters(methodDef.GenericParameters);
 				}
 				else
@@ -117,6 +127,48 @@ namespace Confuser.Renamer {
 		{
 			foreach (var param in genericParams)
 				param.Name = ((char) (param.Number + 1)).ToString();
+		}
+
+		/// <summary>
+		///     Determines whether overload confusion can safely be applied to the method.
+		///     Only applies to non-virtual, non-interface, non-special methods.
+		/// </summary>
+		static bool CanApplyOverloadConfusion(MethodDef method, INameService service) {
+			if (method.IsVirtual || method.IsAbstract || method.IsConstructor)
+				return false;
+			if (method.IsSpecialName || method.IsRuntimeSpecialName)
+				return false;
+			// Skip if method has override/sibling references (VTable constrained)
+			var refs = service.GetReferences(method);
+			if (refs.Any(r => r.ShouldCancelRename || r.DelayRenaming(service, method)))
+				return false;
+			return true;
+		}
+
+		/// <summary>
+		///     Gets a shared overload name for the method's declaring type.
+		///     Methods with different signatures in the same type get the same name.
+		/// </summary>
+		string GetOverloadName(MethodDef method, NameService service, RenameMode mode) {
+			var declType = method.DeclaringType;
+			if (!_overloadNames.TryGetValue(declType, out var names)) {
+				names = new List<string>();
+				_overloadNames[declType] = names;
+			}
+
+			// Check if any existing name can be reused (different signature = safe to share)
+			foreach (var existingName in names) {
+				bool signatureConflict = declType.Methods.Any(m =>
+					m.Name == existingName &&
+					new SigComparer().Equals(m.MethodSig, method.MethodSig));
+				if (!signatureConflict)
+					return existingName;
+			}
+
+			// No reusable name — generate a new one
+			var newName = service.ObfuscateName(method, mode);
+			names.Add(newName);
+			return newName;
 		}
 
 		static IEnumerable<IDnlibDef> GetTargetsWithDelay(IList<IDnlibDef> definitions, ConfuserContext context, INameService service) {

--- a/Confuser.Runtime/Compressor.cs
+++ b/Confuser.Runtime/Compressor.cs
@@ -60,7 +60,8 @@ namespace Confuser.Runtime {
 			AppDomain.CurrentDomain.AssemblyResolve += Resolve;
 
 			// For some reasons, reflection on Assembly would not discover the types unless GetTypes is called.
-			m.GetTypes();
+			try { m.GetTypes(); }
+			catch (ReflectionTypeLoadException) { }
 
 			MethodBase e = m.ResolveMethod(key[0] | (key[1] << 8) | (key[2] << 16) | (key[3] << 24));
 			var g = new object[e.GetParameters().Length];

--- a/Confuser2.sln
+++ b/Confuser2.sln
@@ -20,6 +20,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Confuser.Runtime", "Confuse
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConfuserEx", "ConfuserEx\ConfuserEx.csproj", "{B5205EBA-EC32-4C53-86A0-FAEEE7393EC0}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Confuser.Analyzers", "Confuser.Analyzers\Confuser.Analyzers.csproj", "{F1A2B3C4-D5E6-7890-ABCD-EF1234567890}"
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{356BDB31-853E-43BB-8F9A-D8AC08F69EBB}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CompressorWithResx", "Tests\CompressorWithResx\CompressorWithResx.csproj", "{32223BE8-3E78-489C-92ED-7900B26DFF43}"
@@ -965,6 +967,18 @@ Global
 		{F7581FB4-FAF5-4CD0-888A-B588F5BC69CD}.Release|x64.Build.0 = Release|Any CPU
 		{F7581FB4-FAF5-4CD0-888A-B588F5BC69CD}.Release|x86.ActiveCfg = Release|Any CPU
 		{F7581FB4-FAF5-4CD0-888A-B588F5BC69CD}.Release|x86.Build.0 = Release|Any CPU
+		{F1A2B3C4-D5E6-7890-ABCD-EF1234567890}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F1A2B3C4-D5E6-7890-ABCD-EF1234567890}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F1A2B3C4-D5E6-7890-ABCD-EF1234567890}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F1A2B3C4-D5E6-7890-ABCD-EF1234567890}.Debug|x64.Build.0 = Debug|Any CPU
+		{F1A2B3C4-D5E6-7890-ABCD-EF1234567890}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F1A2B3C4-D5E6-7890-ABCD-EF1234567890}.Debug|x86.Build.0 = Debug|Any CPU
+		{F1A2B3C4-D5E6-7890-ABCD-EF1234567890}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F1A2B3C4-D5E6-7890-ABCD-EF1234567890}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F1A2B3C4-D5E6-7890-ABCD-EF1234567890}.Release|x64.ActiveCfg = Release|Any CPU
+		{F1A2B3C4-D5E6-7890-ABCD-EF1234567890}.Release|x64.Build.0 = Release|Any CPU
+		{F1A2B3C4-D5E6-7890-ABCD-EF1234567890}.Release|x86.ActiveCfg = Release|Any CPU
+		{F1A2B3C4-D5E6-7890-ABCD-EF1234567890}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ConfuserEx.Common.props
+++ b/ConfuserEx.Common.props
@@ -23,7 +23,8 @@
   </PropertyGroup> 
   
   <PropertyGroup Label="Code Analysis">
-	<EnableCodeAnalysis>false</EnableCodeAnalysis>
+	<EnableNETAnalyzers>true</EnableNETAnalyzers>
+	<AnalysisLevel>latest</AnalysisLevel>
   </PropertyGroup>
   
 </Project>

--- a/ConfuserEx.Common.targets
+++ b/ConfuserEx.Common.targets
@@ -7,5 +7,12 @@
     <PackageReference Include="Roslynator.Analyzers" Version="4.*" PrivateAssets="all"
 					  Condition="'$(EnableNETAnalyzers)' != 'false'" />
   </ItemGroup>
+
+  <!-- Custom ConfuserEx analyzers (CX001-CX004) -->
+  <ItemGroup Condition="'$(MSBuildProjectName)' != 'Confuser.Analyzers'">
+    <ProjectReference Include="$(MSBuildThisFileDirectory)Confuser.Analyzers\Confuser.Analyzers.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false" />
+  </ItemGroup>
   
 </Project>

--- a/ConfuserEx.Common.targets
+++ b/ConfuserEx.Common.targets
@@ -5,6 +5,8 @@
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.255" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.*" PrivateAssets="all"
 					  Condition="'$(EnableNETAnalyzers)' != 'false'" />
+    <PackageReference Include="Roslynator.Analyzers" Version="4.*" PrivateAssets="all"
+					  Condition="'$(EnableNETAnalyzers)' != 'false'" />
   </ItemGroup>
   
 </Project>

--- a/ConfuserEx.Common.targets
+++ b/ConfuserEx.Common.targets
@@ -3,8 +3,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.255" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.*" PrivateAssets="all"
-					  Condition="'$(EnableNETAnalyzers)' != 'false'" />
+    <!-- NetAnalyzers shipped with SDK — no explicit package needed -->
     <PackageReference Include="Roslynator.Analyzers" Version="4.*" PrivateAssets="all"
 					  Condition="'$(EnableNETAnalyzers)' != 'false'" />
   </ItemGroup>

--- a/ConfuserEx.Common.targets
+++ b/ConfuserEx.Common.targets
@@ -13,6 +13,7 @@
     <ProjectReference Include="$(MSBuildThisFileDirectory)Confuser.Analyzers\Confuser.Analyzers.csproj"
                       OutputItemType="Analyzer"
                       ReferenceOutputAssembly="false"
+                      SetTargetFramework="TargetFramework=netstandard2.0"
                       SkipGetTargetFrameworkProperties="true" />
   </ItemGroup>
   

--- a/ConfuserEx.Common.targets
+++ b/ConfuserEx.Common.targets
@@ -3,8 +3,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.255" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="*" PrivateAssets="all"
-					  Condition="'$(EnableCodeAnalysis)' != 'false'" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.*" PrivateAssets="all"
+					  Condition="'$(EnableNETAnalyzers)' != 'false'" />
   </ItemGroup>
   
 </Project>

--- a/ConfuserEx.Common.targets
+++ b/ConfuserEx.Common.targets
@@ -8,8 +8,8 @@
 					  Condition="'$(EnableNETAnalyzers)' != 'false'" />
   </ItemGroup>
 
-  <!-- Custom ConfuserEx analyzers (CX001-CX004) -->
-  <ItemGroup Condition="'$(MSBuildProjectName)' != 'Confuser.Analyzers'">
+  <!-- Custom ConfuserEx analyzers (CX001-CX004) — exclude self and net20 Runtime -->
+  <ItemGroup Condition="'$(MSBuildProjectName)' != 'Confuser.Analyzers' AND '$(MSBuildProjectName)' != 'Confuser.Runtime'">
     <ProjectReference Include="$(MSBuildThisFileDirectory)Confuser.Analyzers\Confuser.Analyzers.csproj"
                       OutputItemType="Analyzer"
                       ReferenceOutputAssembly="false" />

--- a/ConfuserEx.Common.targets
+++ b/ConfuserEx.Common.targets
@@ -8,11 +8,12 @@
 					  Condition="'$(EnableNETAnalyzers)' != 'false'" />
   </ItemGroup>
 
-  <!-- Custom ConfuserEx analyzers (CX001-CX004) — exclude self and net20 Runtime -->
-  <ItemGroup Condition="'$(MSBuildProjectName)' != 'Confuser.Analyzers' AND '$(MSBuildProjectName)' != 'Confuser.Runtime'">
+  <!-- Custom ConfuserEx analyzers (CX001-CX004) — all projects including net20 -->
+  <ItemGroup Condition="'$(MSBuildProjectName)' != 'Confuser.Analyzers'">
     <ProjectReference Include="$(MSBuildThisFileDirectory)Confuser.Analyzers\Confuser.Analyzers.csproj"
                       OutputItemType="Analyzer"
-                      ReferenceOutputAssembly="false" />
+                      ReferenceOutputAssembly="false"
+                      SkipGetTargetFrameworkProperties="true" />
   </ItemGroup>
   
 </Project>

--- a/ConfuserEx/ComponentDiscovery.cs
+++ b/ConfuserEx/ComponentDiscovery.cs
@@ -11,8 +11,11 @@ namespace ConfuserEx {
 			ConfuserEngine.Version.ToString();
 
 			Assembly assembly = Assembly.LoadFile(ctx.PluginPath);
-			foreach (var module in assembly.GetLoadedModules())
-				foreach (var i in module.GetTypes()) {
+			foreach (var module in assembly.GetLoadedModules()) {
+				Type[] types;
+				try { types = module.GetTypes(); }
+				catch (ReflectionTypeLoadException ex) { types = Array.FindAll(ex.Types, t => t != null); }
+				foreach (var i in types) {
 					if (i.IsAbstract || !PluginDiscovery.HasAccessibleDefConstructor(i))
 						continue;
 
@@ -24,6 +27,7 @@ namespace ConfuserEx {
 						var packer = (Packer)Activator.CreateInstance(i);
 						ctx.AddPacker(Info.FromComponent(packer, ctx.PluginPath));
 					}
+				}
 				}
 		}
 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,16 @@
-# ConfuserEx
+# ConfuserExx
 
-[![Build status][img_build]][build]
-[![Test status][img_test]][test]
-[![CodeFactor][img_codefactor]][codefactor]
-[![Gitter Chat][img_gitter]][gitter]
+[![CI][img_ci]][ci]
+[![CodeQL][img_codeql]][codeql]
 [![MIT License][img_license]][license]
 
-ConfuserEx is a open-source protector for .NET applications.
-It is the successor of [Confuser][confuser] project.
+An actively maintained fork of [ConfuserEx][upstream] — an open-source protector for .NET applications.
+
+> The original [mkaring/ConfuserEx][upstream] has been dormant since 2022. This fork includes bug fixes, new features, and modern .NET support.
 
 ## Features
 
-* Supports .NET Framework 2.0/3.0/3.5/4.0/4.5/4.6/4.7/4.8
+* Supports .NET Framework 2.0/3.5/4.x, .NET Standard 2.0, .NET Core, .NET 5+/6/7/8+
 * Symbol renaming (Support WPF/BAML)
 * Protection against debuggers/profilers
 * Protection against memory dumping
@@ -23,41 +22,74 @@ It is the successor of [Confuser][confuser] project.
 * Embedding dependency
 * Compressing output
 * Extensible plugin API
-* Many more are coming!
+* Roslyn code analysis integration
+* Auto-detection of .NET runtime paths for modern framework support
 
-# Usage
+## What's improved over upstream
 
-```Batchfile
+* Fixed WPF resource renaming, .NET Standard obfuscation, control flow protection
+* Serialization-aware renaming (DataContract, DataMember, JsonProperty)
+* Graceful handling of external/unresolvable assemblies (no more crashes)
+* Auto-detection of .NET Core/5+/6/7/8+ runtime assembly paths
+* CLI `--snkey` and `--snkeypass` options for CI/CD signing
+* Wildcard module loading in `.crproj` files
+* Roslyn analyzers (NetAnalyzers + Roslynator) for code quality
+* GitHub Actions CI/CD with automatic releases
+* Better error messages for .NET 6+ native host executables
+
+## Usage
+
+```bash
 Confuser.CLI.exe <path to project file>
 ```
 
 The project file is a ConfuserEx Project (`*.crproj`).
-The format of project file can be found in [docs\ProjectFormat.md][project_format]
+The format of project file can be found in [docs/ProjectFormat.md][project_format].
 
-# Bug Report
+### CLI Options
 
-See the [Issues Report][issues] section of website.
+```
+-n|noPause   : no pause after finishing protection
+-o|out       : specifies output directory
+-probe       : specifies probe directory
+-plugin      : specifies plugin path
+-debug       : specifies debug symbol generation
+-snkey       : specifies strong name key file path
+-snkeypass   : specifies strong name key password
+```
 
-# License
+## Bug Report
+
+See the [Issues][issues] section. Please check existing issues before filing a new one.
+
+## Contributing
+
+1. Fork the repository
+2. Create a feature branch from `pre-release`
+3. Make your changes and ensure CI passes
+4. Open a PR targeting `pre-release`
+
+## License
 
 Licensed under the MIT license. See [LICENSE.md][license] for details.
 
-# Credits
+## Credits
 
-**[0xd4d]** for his awesome work and extensive knowledge!
+**[0xd4d]** for [dnlib][dnlib] and extensive .NET metadata knowledge.
+**[Ki (yck1509)][ki]** for the original ConfuserEx.
+**[Martin Karing][mkaring]** for maintaining the project through v1.6.
 
 [0xd4d]: https://github.com/0xd4d
-[build]: https://ci.appveyor.com/project/mkaring/confuserex/branch/master
-[codefactor]: https://www.codefactor.io/repository/github/mkaring/confuserex/overview/master
-[confuser]: http://confuser.codeplex.com
-[issues]: https://github.com/mkaring/ConfuserEx/issues
-[gitter]: https://gitter.im/ConfuserEx/community
+[dnlib]: https://github.com/0xd4d/dnlib
+[ki]: https://github.com/yck1509
+[mkaring]: https://github.com/mkaring
+[upstream]: https://github.com/mkaring/ConfuserEx
+[ci]: https://github.com/mcpolo99/ConfuserExx/actions/workflows/ci.yml
+[codeql]: https://github.com/mcpolo99/ConfuserExx/actions/workflows/codeql-analysis.yml
+[issues]: https://github.com/mcpolo99/ConfuserExx/issues
 [license]: LICENSE.md
 [project_format]: docs/ProjectFormat.md
-[test]: https://ci.appveyor.com/project/mkaring/confuserex/branch/master/tests
 
-[img_build]: https://img.shields.io/appveyor/ci/mkaring/ConfuserEx/master.svg?style=flat
-[img_codefactor]: https://www.codefactor.io/repository/github/mkaring/confuserex/badge/master
-[img_gitter]: https://img.shields.io/gitter/room/mkaring/ConfuserEx.svg?style=flat
-[img_license]: https://img.shields.io/github/license/mkaring/ConfuserEx.svg?style=flat
-[img_test]: https://img.shields.io/appveyor/tests/mkaring/ConfuserEx/master.svg?style=flat&compact_message
+[img_ci]: https://github.com/mcpolo99/ConfuserExx/actions/workflows/ci.yml/badge.svg?branch=pre-release
+[img_codeql]: https://github.com/mcpolo99/ConfuserExx/actions/workflows/codeql-analysis.yml/badge.svg
+[img_license]: https://img.shields.io/github/license/mcpolo99/ConfuserExx.svg?style=flat


### PR DESCRIPTION
Fixes #49

## Custom Analyzers (Confuser.Analyzers project)

| ID | Severity | Pattern | Prevents |
|----|----------|---------|----------|
| CX001 | Error | `module.Import(typeof(X).GetMethod(...))` — host runtime import | Wrong mscorlib version |
| CX002 | Warning | `ResolveTypeDef()`/`ResolveMethodDef()` result used without null check | Crashes on external assemblies |
| CX003 | Info | `ResolveThrow`/`ResolveTypeDefThrow` usage audit | Awareness of crash-on-failure points |
| CX004 | Warning | `Assembly.GetTypes()` without `ReflectionTypeLoadException` catch | Plugin/packer load crashes |

## Violations Fixed

**CX004:**
- `PluginDiscovery.cs` — catch `ReflectionTypeLoadException`, continue with loaded types
- `ComponentDiscovery.cs` — same fix for GUI discovery

**CX002:**
- `VTableAnalyzer.cs:355-356` — null guard on two unprotected `ResolveTypeDef()` calls

**CX001:** Already fixed by PR #31 (`Utils.Import` resolves via CorLib). Analyzer prevents regressions.

## Integration
- New `Confuser.Analyzers` project (netstandard2.0) added to solution
- Wired into all projects via `ConfuserEx.Common.targets` ProjectReference with `OutputItemType=Analyzer`
- Excluded from self-analysis via `MSBuildProjectName` condition