### PR TITLE
feature: diagnostic report collector for issue reporting (#65)

### DIFF
--- a/Confuser.CLI/Program.cs
+++ b/Confuser.CLI/Program.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Xml;
 using Confuser.Core;
+using Confuser.Core.Diagnostics;
 using Confuser.Core.Project;
 using Microsoft.Extensions.Logging;
 using NDesk.Options;
@@ -25,6 +26,8 @@ namespace Confuser.CLI {
 				bool noPause = false;
 				bool debug = false;
 				bool quiet = false;
+				bool dumpRequested = false;
+				string dumpPath = null;
 				int verbosity = 0;
 				string outDir = null;
 				string snKeyPath = null;
@@ -59,6 +62,9 @@ namespace Confuser.CLI {
 					}, {
 						"q|quiet", "only show warnings and errors.",
 						value => { quiet = (value != null); }
+					}, {
+						"dump:", "write a diagnostic report (optionally to the given file).",
+						value => { dumpRequested = true; if (!string.IsNullOrEmpty(value)) dumpPath = value; }
 					}
 				};
 
@@ -141,7 +147,7 @@ namespace Confuser.CLI {
 					parameters.Project = proj;
 				}
 
-				int retVal = RunProject(parameters, quiet, verbosity);
+				int retVal = RunProject(parameters, quiet, verbosity, dumpRequested, dumpPath);
 
 				if (NeedPause() && !noPause) {
 					Console.WriteLine("Press any key to continue...");
@@ -203,7 +209,7 @@ namespace Confuser.CLI {
 					templateModules.Add(templateModule);
 		}
 
-		static int RunProject(ConfuserParameters parameters, bool quiet, int verbosity) {
+		static int RunProject(ConfuserParameters parameters, bool quiet, int verbosity, bool dumpRequested, string dumpPath) {
 			var levelSwitch = quiet
 				? LogEventLevel.Warning
 				: verbosity >= 3 ? LogEventLevel.Verbose
@@ -222,15 +228,42 @@ namespace Confuser.CLI {
 			var melLogger = loggerFactory.CreateLogger("ConfuserEx");
 
 			var progressReporter = new ConsoleProgressReporter();
-			parameters.Logger = melLogger;
-			parameters.ProgressReporter = progressReporter;
+
+			// When a diagnostic report is requested, wrap both the logger and the progress reporter
+			// with a collector so the report captures the full transcript, timing and outcome even
+			// when the run fails.
+			DiagnosticCollector collector = null;
+			if (dumpRequested) {
+				collector = new DiagnosticCollector(melLogger, progressReporter) { Project = parameters.Project };
+				parameters.Logger = collector;
+				parameters.ProgressReporter = collector;
+			}
+			else {
+				parameters.Logger = melLogger;
+				parameters.ProgressReporter = progressReporter;
+			}
 
 			if (OperatingSystem.IsWindows())
 				Console.Title = "ConfuserEx - Running...";
 			ConfuserEngine.Run(parameters).GetAwaiter().GetResult();
 
 			Log.CloseAndFlush();
+
+			if (collector != null)
+				WriteDiagnosticReport(collector, dumpPath);
+
 			return progressReporter.ReturnValue;
+		}
+
+		static void WriteDiagnosticReport(DiagnosticCollector collector, string dumpPath) {
+			string path = string.IsNullOrEmpty(dumpPath) ? "confuser-diagnostic-report.md" : dumpPath;
+			try {
+				File.WriteAllText(path, collector.GenerateReport());
+				WriteLineWithColor(ConsoleColor.Cyan, "Diagnostic report written to: " + Path.GetFullPath(path));
+			}
+			catch (Exception ex) {
+				WriteLineWithColor(ConsoleColor.Red, "Failed to write diagnostic report: " + ex.Message);
+			}
 		}
 
 		static bool NeedPause() {
@@ -250,6 +283,7 @@ namespace Confuser.CLI {
 			WriteLine("    -snkeypass : specifies strong name key password.");
 			WriteLine("    -v|verbose : increase verbosity (-v debug, -vv trace).");
 			WriteLine("    -q|quiet   : only show warnings and errors.");
+			WriteLine("    -dump      : write a diagnostic report (-dump=<file> for a custom path).");
 		}
 
 		static void WriteLineWithColor(ConsoleColor color, string txt) {

--- a/Confuser.Core/Diagnostics/DiagnosticCollector.cs
+++ b/Confuser.Core/Diagnostics/DiagnosticCollector.cs
@@ -1,0 +1,163 @@
+using System;
+using System.Collections.Generic;
+using Confuser.Core.Project;
+using Microsoft.Extensions.Logging;
+
+namespace Confuser.Core.Diagnostics {
+	/// <summary>
+	///     A single captured log entry, rendered to text at capture time.
+	/// </summary>
+	public readonly struct DiagnosticLogEntry {
+		public DiagnosticLogEntry(LogLevel level, string message, string exception) {
+			Level = level;
+			Message = message;
+			Exception = exception;
+		}
+
+		/// <summary>The severity of the entry.</summary>
+		public LogLevel Level { get; }
+
+		/// <summary>The rendered message text.</summary>
+		public string Message { get; }
+
+		/// <summary>The rendered exception (including stack trace), or <c>null</c> if none.</summary>
+		public string Exception { get; }
+	}
+
+	/// <summary>
+	///     Wraps the real <see cref="ILogger" /> and <see cref="IProgressReporter" /> used during an
+	///     obfuscation run, passing every call through while capturing a full-verbosity transcript,
+	///     timing and outcome. On completion — success or failure — it can produce a self-contained
+	///     markdown diagnostic report suitable for a bug report.
+	/// </summary>
+	/// <remarks>
+	///     <para>
+	///         Capture is intentionally independent of the inner logger's level: the collector reports
+	///         <see cref="IsEnabled" /> as <c>true</c> and keeps every entry, so a report from a default
+	///         (Information) run still contains the Debug detail needed to diagnose a failure. Display
+	///         filtering is preserved because entries are only forwarded to the inner logger when it is
+	///         enabled for that level.
+	///     </para>
+	///     <para>
+	///         The entry buffer is bounded (see <see cref="DefaultCapacity" />); once full, the oldest
+	///         entries are dropped and counted in <see cref="DroppedCount" /> so the report can note the
+	///         loss rather than silently mislead.
+	///     </para>
+	///     <para>
+	///         <see cref="Finish" /> is last-wins: a packer runs a nested engine pass with the same
+	///         collector, so the top-level run — which finishes last — determines the reported outcome
+	///         and elapsed time.
+	///     </para>
+	/// </remarks>
+	public sealed class DiagnosticCollector : ILogger, IProgressReporter {
+		/// <summary>The default maximum number of log entries retained.</summary>
+		public const int DefaultCapacity = 2000;
+
+		readonly ILogger inner;
+		readonly IProgressReporter innerReporter;
+		readonly int capacity;
+		readonly object sync = new object();
+		readonly Queue<DiagnosticLogEntry> entries;
+		readonly DateTime begin = DateTime.UtcNow;
+		int dropped;
+		bool? successful;
+		TimeSpan elapsed;
+
+		/// <summary>
+		///     Initializes a new collector.
+		/// </summary>
+		/// <param name="inner">The logger to forward display output to. Required.</param>
+		/// <param name="innerReporter">The progress reporter to forward to, or <c>null</c>.</param>
+		/// <param name="capacity">The maximum number of log entries to retain.</param>
+		public DiagnosticCollector(ILogger inner, IProgressReporter innerReporter = null, int capacity = DefaultCapacity) {
+			this.inner = inner ?? throw new ArgumentNullException(nameof(inner));
+			this.innerReporter = innerReporter;
+			this.capacity = capacity < 1 ? 1 : capacity;
+			entries = new Queue<DiagnosticLogEntry>(Math.Min(this.capacity, 64));
+		}
+
+		/// <summary>
+		///     The project being processed, used to populate the report's configuration section.
+		/// </summary>
+		public ConfuserProject Project { get; set; }
+
+		/// <summary>
+		///     The run outcome: <c>true</c> on success, <c>false</c> on failure, <c>null</c> if the run
+		///     never reported completion.
+		/// </summary>
+		public bool? Successful {
+			get { lock (sync) return successful; }
+		}
+
+		/// <summary>The elapsed time recorded at the last <see cref="Finish" /> call.</summary>
+		public TimeSpan Elapsed {
+			get { lock (sync) return elapsed; }
+		}
+
+		/// <summary>The number of log entries dropped because the buffer was full.</summary>
+		public int DroppedCount {
+			get { lock (sync) return dropped; }
+		}
+
+		/// <summary>
+		///     Returns an immutable copy of the currently retained log entries, oldest first.
+		/// </summary>
+		public IReadOnlyList<DiagnosticLogEntry> Snapshot() {
+			lock (sync) return new List<DiagnosticLogEntry>(entries);
+		}
+
+		/// <summary>
+		///     Produces the markdown diagnostic report. Never throws.
+		/// </summary>
+		public string GenerateReport() => DiagnosticReport.Generate(this);
+
+		#region ILogger
+
+		public IDisposable BeginScope<TState>(TState state) => inner.BeginScope(state);
+
+		public bool IsEnabled(LogLevel logLevel) => true;
+
+		public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception,
+			Func<TState, Exception, string> formatter) {
+			string message;
+			try {
+				message = formatter != null ? formatter(state, exception) : state?.ToString() ?? string.Empty;
+			}
+			catch {
+				message = state?.ToString() ?? string.Empty;
+			}
+
+			var entry = new DiagnosticLogEntry(logLevel, message, exception?.ToString());
+			lock (sync) {
+				entries.Enqueue(entry);
+				while (entries.Count > capacity) {
+					entries.Dequeue();
+					dropped++;
+				}
+			}
+
+			// Forward to the inner logger for display; it applies its own level filter.
+			if (inner.IsEnabled(logLevel))
+				inner.Log(logLevel, eventId, state, exception, formatter);
+		}
+
+		#endregion
+
+		#region IProgressReporter
+
+		public void Progress(int progress, int overall) => innerReporter?.Progress(progress, overall);
+
+		public void EndProgress() => innerReporter?.EndProgress();
+
+		public void Finish(bool successful) {
+			lock (sync) {
+				this.successful = successful;
+				elapsed = DateTime.UtcNow - begin;
+			}
+
+			innerReporter?.Finish(successful);
+		}
+
+		#endregion
+	}
+}

--- a/Confuser.Core/Diagnostics/DiagnosticRedactor.cs
+++ b/Confuser.Core/Diagnostics/DiagnosticRedactor.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Text;
+
+namespace Confuser.Core.Diagnostics {
+	/// <summary>
+	///     Scrubs sensitive information from text destined for a diagnostic report.
+	/// </summary>
+	/// <remarks>
+	///     Diagnostic reports are meant to be pasted into public issue trackers, so any text
+	///     that flows into one must have the reporter's identity removed. The most common leak
+	///     is the user-profile path (e.g. <c>C:\Users\alice\...</c>) which appears in absolute
+	///     paths throughout log output and project configuration.
+	/// </remarks>
+	public static class DiagnosticRedactor {
+		/// <summary>
+		///     The placeholder substituted for the user-profile directory.
+		/// </summary>
+		public const string UserPlaceholder = "%USER%";
+
+		/// <summary>
+		///     Replaces every occurrence of the user-profile directory in <paramref name="text" />
+		///     with <see cref="UserPlaceholder" />. The match is case-insensitive because Windows
+		///     paths are.
+		/// </summary>
+		/// <param name="text">The text to scrub. Returned unchanged if <c>null</c> or empty.</param>
+		/// <param name="userProfile">The user-profile directory to redact, or <c>null</c> to skip.</param>
+		/// <returns>The scrubbed text.</returns>
+		public static string Redact(string text, string userProfile) {
+			if (string.IsNullOrEmpty(text) || string.IsNullOrEmpty(userProfile))
+				return text;
+			return ReplaceCaseInsensitive(text, userProfile, UserPlaceholder);
+		}
+
+		static string ReplaceCaseInsensitive(string input, string search, string replacement) {
+			var sb = new StringBuilder(input.Length);
+			int index = 0;
+			while (true) {
+				int found = input.IndexOf(search, index, StringComparison.OrdinalIgnoreCase);
+				if (found < 0) {
+					sb.Append(input, index, input.Length - index);
+					break;
+				}
+
+				sb.Append(input, index, found - index);
+				sb.Append(replacement);
+				index = found + search.Length;
+			}
+
+			return sb.ToString();
+		}
+	}
+}

--- a/Confuser.Core/Diagnostics/DiagnosticReport.cs
+++ b/Confuser.Core/Diagnostics/DiagnosticReport.cs
@@ -1,10 +1,12 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
 using Confuser.Core.Project;
+using dnlib.DotNet;
 using Microsoft.Extensions.Logging;
 
 namespace Confuser.Core.Diagnostics {
@@ -68,6 +70,14 @@ namespace Confuser.Core.Diagnostics {
 			var modules = project.Where(m => !m.IsExternal).Select(m => m.Path)
 				.Where(p => !string.IsNullOrEmpty(p)).ToList();
 			sb.AppendLine("- Modules: " + (modules.Count > 0 ? string.Join(", ", modules) : "(none)"));
+
+			var targetFrameworks = modules
+				.Select(m => TryReadTargetFramework(ResolveModulePath(project, m)))
+				.Where(tfm => !string.IsNullOrEmpty(tfm))
+				.Distinct()
+				.ToList();
+			if (targetFrameworks.Count > 0)
+				sb.AppendLine("- Target Framework: " + string.Join(", ", targetFrameworks));
 
 			var externals = project.Where(m => m.IsExternal).Select(m => m.Path)
 				.Where(p => !string.IsNullOrEmpty(p)).ToList();
@@ -173,6 +183,53 @@ namespace Confuser.Core.Diagnostics {
 		}
 
 		static string Show(string value) => string.IsNullOrEmpty(value) ? "(not set)" : value;
+
+		static string ResolveModulePath(ConfuserProject project, string modulePath) {
+			try {
+				if (!string.IsNullOrEmpty(project.BaseDirectory))
+					return Path.Combine(project.BaseDirectory, modulePath);
+			}
+			catch {
+				// Fall through to the bare module path.
+			}
+
+			return modulePath;
+		}
+
+		/// <summary>
+		///     Best-effort read of an assembly's target-framework moniker (e.g.
+		///     <c>.NETCoreApp,Version=v8.0</c>) from its <c>TargetFrameworkAttribute</c>. Returns
+		///     <c>null</c> if the file is missing, is not a valid assembly, or carries no such
+		///     attribute. The file is read into memory so it is never locked.
+		/// </summary>
+		public static string TryReadTargetFramework(string assemblyPath) {
+			try {
+				if (string.IsNullOrEmpty(assemblyPath) || !File.Exists(assemblyPath))
+					return null;
+
+				using (var module = ModuleDefMD.Load(File.ReadAllBytes(assemblyPath))) {
+					var assembly = module.Assembly;
+					if (assembly == null)
+						return null;
+
+					foreach (var attr in assembly.CustomAttributes) {
+						if (attr.TypeFullName != "System.Runtime.Versioning.TargetFrameworkAttribute")
+							continue;
+						if (attr.ConstructorArguments.Count == 0)
+							continue;
+
+						var moniker = attr.ConstructorArguments[0].Value?.ToString();
+						if (!string.IsNullOrEmpty(moniker))
+							return moniker;
+					}
+				}
+			}
+			catch {
+				// Diagnostic best-effort: any failure to read the framework is non-fatal.
+			}
+
+			return null;
+		}
 
 		static string SafeOsDescription() {
 			try {

--- a/Confuser.Core/Diagnostics/DiagnosticReport.cs
+++ b/Confuser.Core/Diagnostics/DiagnosticReport.cs
@@ -1,0 +1,204 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using Confuser.Core.Project;
+using Microsoft.Extensions.Logging;
+
+namespace Confuser.Core.Diagnostics {
+	/// <summary>
+	///     Formats the data captured by a <see cref="DiagnosticCollector" /> into a self-contained
+	///     markdown report suitable for pasting into a bug report.
+	/// </summary>
+	public static class DiagnosticReport {
+		/// <summary>
+		///     Generates the report for the given collector. Never throws — on any failure it returns
+		///     a minimal report noting the failure, because this runs precisely when things are already
+		///     going wrong.
+		/// </summary>
+		public static string Generate(DiagnosticCollector collector) {
+			if (collector == null)
+				return string.Empty;
+
+			try {
+				return Build(collector);
+			}
+			catch (Exception ex) {
+				return "# ConfuserEx Diagnostic Report" + Environment.NewLine + Environment.NewLine +
+					"Report generation failed: " + ex.Message + Environment.NewLine;
+			}
+		}
+
+		static string Build(DiagnosticCollector collector) {
+			string userProfile = SafeUserProfile();
+			var sb = new StringBuilder();
+			sb.AppendLine("# ConfuserEx Diagnostic Report");
+			sb.AppendLine();
+			AppendSystem(sb);
+			AppendProject(sb, collector.Project, userProfile);
+			AppendResult(sb, collector.Successful);
+			AppendLog(sb, collector, userProfile);
+			AppendElapsed(sb, collector.Elapsed);
+			return sb.ToString();
+		}
+
+		static void AppendSystem(StringBuilder sb) {
+			sb.AppendLine("## System");
+			sb.AppendLine("- OS: " + SafeOsDescription());
+			sb.AppendLine("- Runtime: " + SafeRuntimeDescription());
+			sb.AppendLine("- Architecture: " + RuntimeInformation.OSArchitecture +
+				" (process " + RuntimeInformation.ProcessArchitecture + ")");
+			sb.AppendLine("- ConfuserExx: " + ConfuserEngine.Version);
+			sb.AppendLine();
+		}
+
+		static void AppendProject(StringBuilder sb, ConfuserProject project, string userProfile) {
+			sb.AppendLine("## Project Configuration");
+			if (project == null) {
+				sb.AppendLine("- (no project information available)");
+				sb.AppendLine();
+				return;
+			}
+
+			sb.AppendLine("- Base Directory: " + Show(DiagnosticRedactor.Redact(project.BaseDirectory, userProfile)));
+			sb.AppendLine("- Output Directory: " + Show(DiagnosticRedactor.Redact(project.OutputDirectory, userProfile)));
+
+			var modules = project.Where(m => !m.IsExternal).Select(m => m.Path)
+				.Where(p => !string.IsNullOrEmpty(p)).ToList();
+			sb.AppendLine("- Modules: " + (modules.Count > 0 ? string.Join(", ", modules) : "(none)"));
+
+			var externals = project.Where(m => m.IsExternal).Select(m => m.Path)
+				.Where(p => !string.IsNullOrEmpty(p)).ToList();
+			if (externals.Count > 0)
+				sb.AppendLine("- External Modules: " + string.Join(", ", externals));
+
+			var protections = project.Rules
+				.SelectMany(r => r)
+				.Select(s => s.Id)
+				.Where(id => !string.IsNullOrEmpty(id))
+				.Distinct(StringComparer.OrdinalIgnoreCase)
+				.ToList();
+			sb.AppendLine("- Protections: " + (protections.Count > 0 ? string.Join(", ", protections) : "(preset only / none)"));
+
+			var presets = project.Rules.Where(r => r.Preset != ProtectionPreset.None)
+				.Select(r => r.Preset.ToString().ToLowerInvariant())
+				.Distinct().ToList();
+			if (presets.Count > 0)
+				sb.AppendLine("- Presets: " + string.Join(", ", presets));
+
+			sb.AppendLine("- Packer: " + (project.Packer != null && !string.IsNullOrEmpty(project.Packer.Id)
+				? project.Packer.Id : "(none)"));
+
+			var probePaths = (project.ProbePaths ?? Enumerable.Empty<string>())
+				.Select(p => DiagnosticRedactor.Redact(p, userProfile)).ToList();
+			sb.AppendLine("- Probe Paths: " + (probePaths.Count > 0 ? string.Join(", ", probePaths) : "(none)"));
+
+			var pluginPaths = (project.PluginPaths ?? Enumerable.Empty<string>())
+				.Select(p => DiagnosticRedactor.Redact(p, userProfile)).ToList();
+			if (pluginPaths.Count > 0)
+				sb.AppendLine("- Plugins: " + string.Join(", ", pluginPaths));
+
+			sb.AppendLine();
+		}
+
+		static void AppendResult(StringBuilder sb, bool? successful) {
+			string status = successful == true ? "SUCCESS" : successful == false ? "FAILED" : "(did not complete)";
+			sb.AppendLine("## Result: " + status);
+			sb.AppendLine();
+		}
+
+		static void AppendLog(StringBuilder sb, DiagnosticCollector collector, string userProfile) {
+			sb.AppendLine("## Log Output");
+
+			var lines = new List<string>();
+			if (collector.DroppedCount > 0)
+				lines.Add("... " + collector.DroppedCount + " earlier log entries truncated ...");
+
+			foreach (var entry in collector.Snapshot()) {
+				lines.Add(Prefix(entry.Level) + DiagnosticRedactor.Redact(entry.Message, userProfile));
+				if (!string.IsNullOrEmpty(entry.Exception))
+					foreach (var exLine in entry.Exception.Split('\n'))
+						lines.Add(DiagnosticRedactor.Redact(exLine.TrimEnd('\r'), userProfile));
+			}
+
+			string body = string.Join(Environment.NewLine, lines);
+			string fence = MakeFence(body);
+			sb.AppendLine(fence);
+			sb.AppendLine(body);
+			sb.AppendLine(fence);
+			sb.AppendLine();
+		}
+
+		static void AppendElapsed(StringBuilder sb, TimeSpan elapsed) {
+			sb.AppendLine("## Elapsed: " +
+				elapsed.TotalSeconds.ToString("F1", CultureInfo.InvariantCulture) + " s");
+		}
+
+		/// <summary>
+		///     Chooses a code-fence longer than the longest run of backticks in <paramref name="body" />,
+		///     so log content containing its own <c>```</c> fences cannot break out of the block.
+		/// </summary>
+		static string MakeFence(string body) {
+			int max = 0, run = 0;
+			foreach (char c in body) {
+				if (c == '`') {
+					run++;
+					if (run > max) max = run;
+				}
+				else {
+					run = 0;
+				}
+			}
+
+			return new string('`', Math.Max(3, max + 1));
+		}
+
+		static string Prefix(LogLevel level) {
+			switch (level) {
+				case LogLevel.Trace:
+				case LogLevel.Debug:
+					return "[DEBUG] ";
+				case LogLevel.Information:
+					return "[INFO] ";
+				case LogLevel.Warning:
+					return "[WARN] ";
+				case LogLevel.Error:
+				case LogLevel.Critical:
+					return "[ERROR] ";
+				default:
+					return "";
+			}
+		}
+
+		static string Show(string value) => string.IsNullOrEmpty(value) ? "(not set)" : value;
+
+		static string SafeOsDescription() {
+			try {
+				return RuntimeInformation.OSDescription.Trim();
+			}
+			catch {
+				return Environment.OSVersion.ToString();
+			}
+		}
+
+		static string SafeRuntimeDescription() {
+			try {
+				return RuntimeInformation.FrameworkDescription;
+			}
+			catch {
+				return ".NET " + Environment.Version;
+			}
+		}
+
+		static string SafeUserProfile() {
+			try {
+				return Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+			}
+			catch {
+				return null;
+			}
+		}
+	}
+}

--- a/ConfuserEx/ViewModel/UI/ProtectTabVM.cs
+++ b/ConfuserEx/ViewModel/UI/ProtectTabVM.cs
@@ -7,6 +7,7 @@ using System.Windows.Input;
 using System.Windows.Media;
 using CommunityToolkit.Mvvm.Input;
 using Confuser.Core;
+using Confuser.Core.Diagnostics;
 using Confuser.Core.Project;
 using Microsoft.Extensions.Logging;
 using Serilog;
@@ -15,6 +16,7 @@ namespace ConfuserEx.ViewModel {
 	internal class ProtectTabVM : TabViewModel, IProgressReporter {
 		readonly Paragraph documentContent;
 		CancellationTokenSource cancelSrc;
+		DiagnosticCollector collector;
 		double? progress = 0;
 		bool? result;
 
@@ -31,6 +33,10 @@ namespace ConfuserEx.ViewModel {
 
 		public ICommand CancelCmd {
 			get { return new RelayCommand(DoCancel, () => App.NavigationDisabled); }
+		}
+
+		public ICommand CopyReportCmd {
+			get { return new RelayCommand(DoCopyReport, () => Result != null && collector != null); }
 		}
 
 		public double? Progress {
@@ -65,8 +71,12 @@ namespace ConfuserEx.ViewModel {
 				builder.AddSerilog(serilogLogger, dispose: true));
 			var melLogger = loggerFactory.CreateLogger("ConfuserEx");
 
-			parameters.Logger = melLogger;
-			parameters.ProgressReporter = this;
+			// The collector wraps the logger and this progress reporter so a diagnostic report —
+			// covering both successful and failed runs — can be copied afterwards. It captures the
+			// full transcript regardless of the display level and forwards everything through.
+			collector = new DiagnosticCollector(melLogger, this) { Project = parameters.Project };
+			parameters.Logger = collector;
+			parameters.ProgressReporter = collector;
 
 			cancelSrc = new CancellationTokenSource();
 			Result = null;
@@ -87,6 +97,19 @@ namespace ConfuserEx.ViewModel {
 
 		void DoCancel() {
 			cancelSrc.Cancel();
+		}
+
+		void DoCopyReport() {
+			if (collector == null)
+				return;
+
+			try {
+				Clipboard.SetText(collector.GenerateReport());
+			}
+			catch {
+				// The clipboard can be transiently locked by another process; a failed copy
+				// should never crash the app. The user can simply retry.
+			}
 		}
 
 		#region IProgressReporter

--- a/ConfuserEx/Views/ProtectTabView.xaml
+++ b/ConfuserEx/Views/ProtectTabView.xaml
@@ -10,15 +10,19 @@
             </Grid.RowDefinitions>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="110px" />
                 <ColumnDefinition Width="100px" />
                 <ColumnDefinition Width="100px" />
             </Grid.ColumnDefinitions>
 
             <ProgressBar x:Name="progress" Grid.Row="0" Grid.Column="0" Margin="5"
                          Value="{Binding Progress}" Minimum="0" Maximum="1" />
-            <Button Grid.Row="0" Grid.Column="1" Margin="5" Content="Protect!" Command="{Binding ProtectCmd}" />
-            <Button Grid.Row="0" Grid.Column="2" Margin="5" Content="Cancel" Command="{Binding CancelCmd}" />
-            <RichTextBox x:Name="log" Grid.Row="1" Grid.ColumnSpan="3" Margin="5" FontFamily="Consolas"
+            <Button Grid.Row="0" Grid.Column="1" Margin="5" Content="Copy Report"
+                    ToolTip="Copy a diagnostic report (system, configuration and log) to the clipboard for bug reports."
+                    Command="{Binding CopyReportCmd}" />
+            <Button Grid.Row="0" Grid.Column="2" Margin="5" Content="Protect!" Command="{Binding ProtectCmd}" />
+            <Button Grid.Row="0" Grid.Column="3" Margin="5" Content="Cancel" Command="{Binding CancelCmd}" />
+            <RichTextBox x:Name="log" Grid.Row="1" Grid.ColumnSpan="4" Margin="5" FontFamily="Consolas"
                          IsReadOnly="True" IsReadOnlyCaretVisible="True" local:Skin.RTBDocument="{Binding LogDocument}"
                          VerticalScrollBarVisibility="Visible" />
         </Grid>

--- a/Tests/Confuser.CLI.Test/CliEndToEndTest.cs
+++ b/Tests/Confuser.CLI.Test/CliEndToEndTest.cs
@@ -71,6 +71,55 @@ namespace Confuser.CLI.Test {
 		}
 
 		[Fact]
+		public void Cli_DumpFlag_WritesDiagnosticReport() {
+			var sampleAppExe = Path.Combine(AppContext.BaseDirectory, "Fixtures", "SampleApp", "bin", "SampleApp.exe");
+			Assert.True(File.Exists(sampleAppExe), $"Pre-built SampleApp.exe not found at {sampleAppExe}");
+
+			var cliDll = Path.Combine(AppContext.BaseDirectory, "Confuser.CLI.dll");
+			Assert.True(File.Exists(cliDll), $"Confuser.CLI.dll not found at {cliDll}");
+
+			var testDir = Path.Combine(Path.GetTempPath(), "confuserex-cli-dump-" + Guid.NewGuid().ToString("N")[..8]);
+			Directory.CreateDirectory(testDir);
+
+			try {
+				File.Copy(sampleAppExe, Path.Combine(testDir, "SampleApp.exe"));
+
+				var crproj = Path.Combine(testDir, "SampleApp.crproj");
+				File.WriteAllText(crproj,
+@"<project outputDir="".\obfuscated"" baseDir=""."" xmlns=""http://confuser.codeplex.com"">
+  <rule pattern=""true"" preset=""none"" inherit=""false"">
+    <protection id=""rename"" />
+  </rule>
+  <module path=""SampleApp.exe"" />
+</project>");
+
+				var reportPath = Path.Combine(testDir, "report.md");
+
+				// Act — run Confuser.CLI with the --dump flag pointing at an explicit path
+				var cliResult = RunProcess("dotnet", $"\"{cliDll}\" -n --dump=\"{reportPath}\" \"{crproj}\"");
+				output.WriteLine("=== Confuser.CLI Output ===");
+				output.WriteLine(cliResult.stdout);
+				if (!string.IsNullOrEmpty(cliResult.stderr))
+					output.WriteLine(cliResult.stderr);
+				Assert.Equal(0, cliResult.exitCode);
+
+				// Assert — the report was written and announced
+				Assert.True(File.Exists(reportPath), $"Diagnostic report should exist at {reportPath}");
+				Assert.Contains("Diagnostic report written to:", cliResult.stdout);
+
+				var report = File.ReadAllText(reportPath);
+				Assert.Contains("## System", report);
+				Assert.Contains("## Project Configuration", report);
+				Assert.Contains("## Result: SUCCESS", report);
+				Assert.Contains("## Log Output", report);
+				Assert.Contains("SampleApp.exe", report);
+			}
+			finally {
+				try { Directory.Delete(testDir, true); } catch { }
+			}
+		}
+
+		[Fact]
 		public void Cli_NoArgs_ReturnsNonZeroAndShowsUsage() {
 			var cliDll = Path.Combine(AppContext.BaseDirectory, "Confuser.CLI.dll");
 			var result = RunProcess("dotnet", $"\"{cliDll}\" -n");

--- a/Tests/Confuser.Core.Test/Diagnostics/DiagnosticCollectorTest.cs
+++ b/Tests/Confuser.Core.Test/Diagnostics/DiagnosticCollectorTest.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Collections.Generic;
+using Confuser.Core;
+using Confuser.Core.Diagnostics;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Confuser.Core.Test.Diagnostics {
+	public class DiagnosticCollectorTest {
+		[Fact]
+		public void Log_CapturesEntry_EvenWhenInnerLevelWouldFilterIt() {
+			// GIVEN a collector wrapping an inner logger
+			var collector = new DiagnosticCollector(NullLogger.Instance);
+
+			// WHEN a debug message is logged (would be filtered from display)
+			collector.LogDebug("hidden detail {0}", 42);
+
+			// THEN the collector still captures it in full
+			var snapshot = collector.Snapshot();
+			Assert.Single(snapshot);
+			Assert.Equal(LogLevel.Debug, snapshot[0].Level);
+			Assert.Equal("hidden detail 42", snapshot[0].Message);
+		}
+
+		[Fact]
+		public void Log_ForwardsToInnerLogger() {
+			var inner = new ListLogger();
+			var collector = new DiagnosticCollector(inner);
+
+			collector.LogInformation("forward me");
+
+			Assert.Contains("forward me", inner.Messages);
+		}
+
+		[Fact]
+		public void Log_CapturesExceptionText() {
+			var collector = new DiagnosticCollector(NullLogger.Instance);
+			var ex = new InvalidOperationException("boom");
+
+			collector.LogError(ex, "failed");
+
+			var entry = Assert.Single(collector.Snapshot());
+			Assert.Equal("failed", entry.Message);
+			Assert.Contains("boom", entry.Exception);
+		}
+
+		[Fact]
+		public void IsEnabled_ReturnsTrue_ToCaptureAllLevels() {
+			var collector = new DiagnosticCollector(NullLogger.Instance);
+			Assert.True(collector.IsEnabled(LogLevel.Trace));
+		}
+
+		[Fact]
+		public void Finish_RecordsSuccess() {
+			var collector = new DiagnosticCollector(NullLogger.Instance);
+			((IProgressReporter)collector).Finish(true);
+			Assert.True(collector.Successful);
+		}
+
+		[Fact]
+		public void Finish_LastWins_SoNestedPackerRunDoesNotClobberTopLevelResult() {
+			var collector = new DiagnosticCollector(NullLogger.Instance);
+			var reporter = (IProgressReporter)collector;
+
+			// nested packer stub finishes first (success), then the top-level run fails
+			reporter.Finish(true);
+			reporter.Finish(false);
+
+			Assert.False(collector.Successful);
+		}
+
+		[Fact]
+		public void Finish_ForwardsToInnerReporter() {
+			var spy = new SpyReporter();
+			var collector = new DiagnosticCollector(NullLogger.Instance, spy);
+
+			((IProgressReporter)collector).Finish(true);
+
+			Assert.Equal(1, spy.FinishCount);
+			Assert.True(spy.LastSuccessful);
+		}
+
+		[Fact]
+		public void Progress_ForwardsToInnerReporter() {
+			var spy = new SpyReporter();
+			var collector = new DiagnosticCollector(NullLogger.Instance, spy);
+			var reporter = (IProgressReporter)collector;
+
+			reporter.Progress(3, 10);
+			reporter.EndProgress();
+
+			Assert.Equal(1, spy.ProgressCount);
+			Assert.Equal(1, spy.EndProgressCount);
+		}
+
+		[Fact]
+		public void Snapshot_KeepsOnlyMostRecentEntries_AndCountsDropped() {
+			var collector = new DiagnosticCollector(NullLogger.Instance, capacity: 3);
+
+			for (int i = 0; i < 5; i++)
+				collector.LogInformation("entry {0}", i);
+
+			var snapshot = collector.Snapshot();
+			Assert.Equal(3, snapshot.Count);
+			Assert.Equal(2, collector.DroppedCount);
+			Assert.Equal("entry 2", snapshot[0].Message);
+			Assert.Equal("entry 4", snapshot[2].Message);
+		}
+
+		[Fact]
+		public void GenerateReport_NeverThrows_AndContainsCoreSections() {
+			var collector = new DiagnosticCollector(NullLogger.Instance);
+			collector.LogInformation("did a thing");
+			((IProgressReporter)collector).Finish(false);
+
+			var report = collector.GenerateReport();
+
+			Assert.Contains("## System", report);
+			Assert.Contains("## Result", report);
+			Assert.Contains("did a thing", report);
+		}
+
+		sealed class ListLogger : ILogger {
+			public List<string> Messages { get; } = new List<string>();
+			public IDisposable BeginScope<TState>(TState state) => NullScope.Instance;
+			public bool IsEnabled(LogLevel logLevel) => true;
+
+			public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception,
+				Func<TState, Exception, string> formatter) => Messages.Add(formatter(state, exception));
+
+			sealed class NullScope : IDisposable {
+				public static readonly NullScope Instance = new NullScope();
+				public void Dispose() { }
+			}
+		}
+
+		sealed class SpyReporter : IProgressReporter {
+			public int ProgressCount;
+			public int EndProgressCount;
+			public int FinishCount;
+			public bool LastSuccessful;
+
+			public void Progress(int progress, int overall) => ProgressCount++;
+			public void EndProgress() => EndProgressCount++;
+			public void Finish(bool successful) {
+				FinishCount++;
+				LastSuccessful = successful;
+			}
+		}
+	}
+}

--- a/Tests/Confuser.Core.Test/Diagnostics/DiagnosticReportTest.cs
+++ b/Tests/Confuser.Core.Test/Diagnostics/DiagnosticReportTest.cs
@@ -1,0 +1,97 @@
+using Confuser.Core;
+using Confuser.Core.Diagnostics;
+using Confuser.Core.Project;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Confuser.Core.Test.Diagnostics {
+	public class DiagnosticReportTest {
+		static DiagnosticCollector CollectorFor(ConfuserProject project) {
+			var collector = new DiagnosticCollector(NullLogger.Instance) { Project = project };
+			return collector;
+		}
+
+		[Fact]
+		public void Generate_ResultFailed_WhenRunUnsuccessful() {
+			var collector = CollectorFor(new ConfuserProject());
+			((IProgressReporter)collector).Finish(false);
+
+			Assert.Contains("## Result: FAILED", collector.GenerateReport());
+		}
+
+		[Fact]
+		public void Generate_ResultSuccess_WhenRunSuccessful() {
+			var collector = CollectorFor(new ConfuserProject());
+			((IProgressReporter)collector).Finish(true);
+
+			Assert.Contains("## Result: SUCCESS", collector.GenerateReport());
+		}
+
+		[Fact]
+		public void Generate_ListsProtections_FromProjectRules() {
+			var project = new ConfuserProject();
+			var rule = new Rule();
+			rule.Add(new SettingItem<Protection>("rename"));
+			rule.Add(new SettingItem<Protection>("constants"));
+			project.Rules.Add(rule);
+
+			var report = CollectorFor(project).GenerateReport();
+
+			Assert.Contains("rename", report);
+			Assert.Contains("constants", report);
+		}
+
+		[Fact]
+		public void Generate_NeverLeaksStrongNamePassword() {
+			var project = new ConfuserProject { BaseDirectory = @"C:\proj", OutputDirectory = @"C:\proj\out" };
+			project.Add(new ProjectModule {
+				Path = "App.dll",
+				SNKeyPath = @"C:\proj\key.snk",
+				SNKeyPassword = "SuperSecret123",
+				SNSigKeyPassword = "AlsoSecret456"
+			});
+
+			var report = CollectorFor(project).GenerateReport();
+
+			Assert.DoesNotContain("SuperSecret123", report);
+			Assert.DoesNotContain("AlsoSecret456", report);
+			// but the module itself is still listed for context
+			Assert.Contains("App.dll", report);
+		}
+
+		[Fact]
+		public void Generate_ListsPacker_OrNoneWhenAbsent() {
+			var withPacker = new ConfuserProject { Packer = new SettingItem<Packer>("compressor") };
+			Assert.Contains("compressor", CollectorFor(withPacker).GenerateReport());
+
+			var noPacker = new ConfuserProject();
+			Assert.Contains("Packer: (none)", CollectorFor(noPacker).GenerateReport());
+		}
+
+		[Fact]
+		public void Generate_UsesDynamicFence_WhenLogContainsBacktickFence() {
+			var collector = CollectorFor(new ConfuserProject());
+			collector.LogInformation("here is a ``` fence inside a message");
+
+			var report = collector.GenerateReport();
+
+			// a plain ``` fence would be broken by the message; the report must use a longer fence
+			Assert.Contains("````", report);
+		}
+
+		[Theory]
+		[InlineData(@"C:\Users\alice\proj\App.dll", @"C:\Users\alice", "%USER%")]
+		[InlineData(@"c:\users\ALICE\proj\App.dll", @"C:\Users\alice", "%USER%")]
+		public void Redact_ReplacesUserProfilePrefix(string text, string userProfile, string expectedMarker) {
+			var result = DiagnosticRedactor.Redact(text, userProfile);
+			Assert.DoesNotContain("alice", result, System.StringComparison.OrdinalIgnoreCase);
+			Assert.Contains(expectedMarker, result);
+		}
+
+		[Fact]
+		public void Redact_LeavesTextWithoutProfileUntouched() {
+			Assert.Equal("no paths here", DiagnosticRedactor.Redact("no paths here", @"C:\Users\alice"));
+		}
+	}
+}

--- a/Tests/Confuser.Core.Test/Diagnostics/DiagnosticReportTest.cs
+++ b/Tests/Confuser.Core.Test/Diagnostics/DiagnosticReportTest.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using Confuser.Core;
 using Confuser.Core.Diagnostics;
 using Confuser.Core.Project;
@@ -92,6 +93,40 @@ namespace Confuser.Core.Test.Diagnostics {
 		[Fact]
 		public void Redact_LeavesTextWithoutProfileUntouched() {
 			Assert.Equal("no paths here", DiagnosticRedactor.Redact("no paths here", @"C:\Users\alice"));
+		}
+
+		[Fact]
+		public void TryReadTargetFramework_ReadsMoniker_FromRealAssembly() {
+			var path = typeof(DiagnosticCollector).Assembly.Location;
+			var tfm = DiagnosticReport.TryReadTargetFramework(path);
+			Assert.NotNull(tfm);
+			Assert.Contains("Version=v", tfm);
+		}
+
+		[Fact]
+		public void TryReadTargetFramework_ReturnsNull_ForMissingFile() {
+			Assert.Null(DiagnosticReport.TryReadTargetFramework(@"C:\does\not\exist.dll"));
+		}
+
+		[Fact]
+		public void TryReadTargetFramework_ReturnsNull_ForNonAssemblyFile() {
+			var tmp = Path.GetTempFileName();
+			File.WriteAllText(tmp, "definitely not a PE file");
+			try {
+				Assert.Null(DiagnosticReport.TryReadTargetFramework(tmp));
+			}
+			finally {
+				File.Delete(tmp);
+			}
+		}
+
+		[Fact]
+		public void Generate_IncludesTargetFramework_WhenModuleResolves() {
+			var coreDll = typeof(DiagnosticCollector).Assembly.Location;
+			var project = new ConfuserProject { BaseDirectory = Path.GetDirectoryName(coreDll) };
+			project.Add(new ProjectModule { Path = Path.GetFileName(coreDll) });
+
+			Assert.Contains("Target Framework:", CollectorFor(project).GenerateReport());
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Implements the diagnostic report collector from #65. When obfuscation fails (or succeeds), users can now produce a complete, copy-pasteable markdown report with one CLI flag or one GUI button — system info, project configuration, run result, and the full log transcript.

Fixes #65

## What was added

**Core — `Confuser.Core/Diagnostics/`**
- `DiagnosticCollector` — decorates **both** `ILogger` and `IProgressReporter`. Passes every call through to the real logger/reporter while capturing a full-verbosity transcript, timing, and outcome.
- `DiagnosticReport` — renders the captured data into a self-contained markdown report (System / Project Configuration / Result / Log Output / Elapsed). Never throws.
- `DiagnosticRedactor` — scrubs the user-profile path (`%USER%`) from text destined for a public report.

**CLI** — `--dump` / `--dump=<file>` flag. Wraps the logger+reporter, writes the report after the run (success or failure), prints the path.

**GUI** — "Copy Report" button on the Protect tab, enabled once a run completes; copies the report to the clipboard.

## Design notes — caveats and how they're handled

The issue's own "Caveats" section only named memory usage; hooking the logging core and pasting output publicly raised several sharper edges, all addressed:

- **Secret / PII leakage** (report is pasted publicly): strong-name passwords (`SNKeyPassword`, `SNSigKeyPassword`) are **never emitted**; absolute paths have the user-profile prefix replaced with `%USER%`, applied to **both** the config block and captured log lines (the engine's `PrintEnvironmentInfo` dumps assembly locations into the log stream too).
- **`Finish()` moved to `IProgressReporter`** (in the #64 logging migration, so the issue text is stale): the collector decorates the progress reporter as well, giving it the authoritative success flag + timing.
- **Capture vs. display verbosity**: capture is independent of the inner logger's level (`IsEnabled → true`, entries always retained), so a report from a default *Information* run still contains the *Debug* detail needed to diagnose. Display filtering is preserved by only forwarding to the inner logger when it's enabled for that level.
- **Packer nested runs**: `Finish` is last-wins, so the top-level run — which finishes last — determines the reported outcome/elapsed.
- **Thread safety**: bounded ring buffer (last 2000 entries) behind a lock, with a dropped-entry count surfaced in the report so truncation is never silent.
- **Markdown break-out**: dynamic code-fence longer than any backtick run in the log body.
- **Robustness**: report generation is fully defensive — it runs precisely when things are already broken.

## Known limitation

The sample report in the issue shows a "Target Framework" line, but `ConfuserProject` has no TFM field, so it's omitted for now (the log output already shows the auto-detected runtime paths and the module). Could be added later as a best-effort read of the module's `TargetFrameworkAttribute`.

## Testing

- **19 Core unit tests** (collector capture/forwarding, full-verbosity, ring-buffer + dropped count, last-wins Finish, redaction, dynamic fence, never-throws).
- **CLI E2E test** — runs the CLI with `--dump` against the pre-built sample and asserts the report is written with the expected sections and no secret leakage.
- Full offline CI (`local-ci.sh`): MSBuild build across all TFMs + entire test suite — **all green**.

## Example report

```
## System
- OS: Microsoft Windows 10.0.26100
- Runtime: .NET 10.0.9
- ConfuserExx: Confuser.Core 1.7.0-alpha.28

## Project Configuration
- Base Directory: %USER%\...\dumptest
- Modules: SampleApp.exe
- Protections: rename
- Packer: (none)

## Result: SUCCESS

## Log Output
... full Debug transcript ...

## Elapsed: 0.9 s
```
