### PR TITLE
chore: reliable offline coverage reporting in local-ci

### DIFF
--- a/scripts/local-ci.sh
+++ b/scripts/local-ci.sh
@@ -247,18 +247,41 @@ do_test() {
   echo -e "  ${BOLD}Total: Passed=$total_passed  Failed=$total_failed  Skipped=$total_skipped${NC}"
   echo "  ─────────────────────────────────────"
 
-  # Generate coverage report if reportgenerator is available
+  # Generate coverage report. reportgenerator is required for the coverage summary;
+  # install it on demand (mirroring the CI workflow) so local runs always produce a
+  # report — including the same markdown summary CI posts to the PR.
   local reports
   reports=$(find "$RESULTS_DIR" -name "coverage.cobertura.xml" 2>/dev/null | tr '\n' ';')
-  if [ -n "$reports" ] && command -v reportgenerator &>/dev/null; then
-    step "COVERAGE — generating report"
-    mkdir -p "$COVERAGE_DIR/report"
-    reportgenerator "-reports:$reports" \
-      "-targetdir:$COVERAGE_DIR/report" \
-      "-reporttypes:TextSummary" 2>/dev/null
-    cat "$COVERAGE_DIR/report/Summary.txt" 2>/dev/null || true
-  elif [ -n "$reports" ]; then
-    warn "Install reportgenerator for coverage reports: dotnet tool install -g dotnet-reportgenerator-globaltool"
+  if [ -n "$reports" ]; then
+    if ! command -v reportgenerator &>/dev/null; then
+      step "COVERAGE — installing reportgenerator (dotnet global tool)"
+      dotnet tool install -g dotnet-reportgenerator-globaltool 2>/dev/null \
+        || dotnet tool update -g dotnet-reportgenerator-globaltool 2>/dev/null || true
+      # Ensure the dotnet global-tools directory is on PATH for this session.
+      export PATH="$PATH:$HOME/.dotnet/tools"
+      if command -v cygpath &>/dev/null && [ -n "${USERPROFILE:-}" ]; then
+        export PATH="$PATH:$(cygpath -u "$USERPROFILE")/.dotnet/tools"
+      fi
+    fi
+
+    if command -v reportgenerator &>/dev/null; then
+      step "COVERAGE — generating report"
+      mkdir -p "$COVERAGE_DIR/report"
+      # Same report types as .github/workflows/test.yml so local output matches CI:
+      # HTML (openable offline), Cobertura, a text summary, and the GitHub markdown
+      # summary that CI posts as the sticky PR comment.
+      reportgenerator "-reports:$reports" \
+        "-targetdir:$COVERAGE_DIR/report" \
+        "-reporttypes:HtmlInline;Cobertura;TextSummary;MarkdownSummaryGithub" 2>/dev/null
+      cat "$COVERAGE_DIR/report/Summary.txt" 2>/dev/null || true
+      [ -f "$COVERAGE_DIR/report/SummaryGithub.md" ] \
+        && success "Markdown summary: $COVERAGE_DIR/report/SummaryGithub.md"
+      [ -f "$COVERAGE_DIR/report/index.html" ] \
+        && success "HTML report:      $COVERAGE_DIR/report/index.html"
+    else
+      warn "reportgenerator unavailable even after install attempt; skipping coverage report."
+      warn "Install manually: dotnet tool install -g dotnet-reportgenerator-globaltool"
+    fi
   fi
 
   if [ "$any_failed" = true ]; then

--- a/scripts/local-ci.sh
+++ b/scripts/local-ci.sh
@@ -11,6 +11,16 @@
 #   ./scripts/local-ci.sh test         # build + test only
 #   ./scripts/local-ci.sh package      # build + package only
 #   ./scripts/local-ci.sh all          # everything (default)
+#
+# GitHub Actions minutes are limited, so full test+coverage runs are expensive to
+# do on every push. This script produces the SAME coverage artifacts locally,
+# including SummaryGithub.md — the markdown that CI would post to the PR. To share
+# it without spending Actions minutes, opt in to posting it as a single sticky PR
+# comment (requires the 'gh' CLI, authenticated):
+#
+#   POST_COVERAGE_PR=88 ./scripts/local-ci.sh test   # post/update coverage on PR #88
+#
+# Posting is opt-in and never happens unless POST_COVERAGE_PR is set.
 # =============================================================================
 
 set -euo pipefail
@@ -37,6 +47,57 @@ step()    { echo -e "\n${CYAN}${BOLD}==> $1${NC}"; }
 success() { echo -e "${GREEN}✓ $1${NC}"; }
 warn()    { echo -e "${YELLOW}⚠ $1${NC}"; }
 fail()    { echo -e "${RED}✗ $1${NC}"; }
+
+# ---------------------------------------------------------------------------
+# Post a coverage summary as a single sticky PR comment (opt-in).
+# Finds a prior comment by a hidden marker and edits it, so repeated runs update
+# one comment instead of spamming — the same behaviour as the CI sticky comment.
+# Failures are warnings only; posting must never fail the pipeline.
+# ---------------------------------------------------------------------------
+post_coverage_comment() {
+  local pr="$1" file="$2"
+  local marker="<!-- local-ci-coverage -->"
+
+  if ! command -v gh &>/dev/null; then
+    warn "gh CLI not found; cannot post coverage comment. Install: https://cli.github.com"
+    return 0
+  fi
+  if [ ! -f "$file" ]; then
+    warn "No coverage summary at $file; nothing to post."
+    return 0
+  fi
+
+  local repo
+  repo=$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null || true)
+  if [ -z "$repo" ]; then
+    warn "Could not resolve the GitHub repository; skipping coverage comment."
+    return 0
+  fi
+
+  local body_file
+  body_file=$(mktemp)
+  { printf '%s\n\n' "$marker"; cat "$file"; } > "$body_file"
+
+  local existing_id
+  existing_id=$(gh api "repos/$repo/issues/$pr/comments" --paginate \
+    --jq "map(select(.body | contains(\"$marker\"))) | last | .id" 2>/dev/null || true)
+
+  if [ -n "$existing_id" ] && [ "$existing_id" != "null" ]; then
+    if gh api -X PATCH "repos/$repo/issues/comments/$existing_id" -F body=@"$body_file" >/dev/null 2>&1; then
+      success "Updated sticky coverage comment on PR #$pr"
+    else
+      warn "Failed to update coverage comment on PR #$pr."
+    fi
+  else
+    if gh api -X POST "repos/$repo/issues/$pr/comments" -F body=@"$body_file" >/dev/null 2>&1; then
+      success "Posted coverage comment on PR #$pr"
+    else
+      warn "Failed to post coverage comment on PR #$pr."
+    fi
+  fi
+
+  rm -f "$body_file"
+}
 
 # ---------------------------------------------------------------------------
 # Find MSBuild via vswhere (CI uses microsoft/setup-msbuild@v2)
@@ -278,6 +339,12 @@ do_test() {
         && success "Markdown summary: $COVERAGE_DIR/report/SummaryGithub.md"
       [ -f "$COVERAGE_DIR/report/index.html" ] \
         && success "HTML report:      $COVERAGE_DIR/report/index.html"
+
+      # Opt-in: post the markdown summary to a PR as a single sticky comment.
+      if [ -n "${POST_COVERAGE_PR:-}" ]; then
+        step "COVERAGE — posting summary to PR #$POST_COVERAGE_PR"
+        post_coverage_comment "$POST_COVERAGE_PR" "$COVERAGE_DIR/report/SummaryGithub.md"
+      fi
     else
       warn "reportgenerator unavailable even after install attempt; skipping coverage report."
       warn "Install manually: dotnet tool install -g dotnet-reportgenerator-globaltool"


### PR DESCRIPTION
## Why

GitHub Actions minutes are a limited budget, and the full **build + test + coverage** matrix (`test.yml`) is the most expensive workflow we run. Reserving it for every push/iteration burns through minutes fast. `local-ci.sh` already reproduces the build and tests offline — this PR makes its **coverage reporting** a first-class, reliable equivalent of what CI produces, so we can iterate locally and only spend Actions minutes when it actually matters.

## What changed (`scripts/local-ci.sh` only)

**1. reportgenerator is now required, not optional**
Previously the coverage step silently no-op'd if `reportgenerator` wasn't installed. Now it installs the `dotnet-reportgenerator-globaltool` on demand (mirroring `test.yml`) and puts the dotnet global-tools dir on `PATH`, so a local run **always** produces a coverage report.

**2. Same report artifacts as CI**
Report types bumped from `TextSummary` only → `HtmlInline;Cobertura;TextSummary;MarkdownSummaryGithub` — matching `test.yml`. A local run now emits:

| Artifact | Path |
|---|---|
| GitHub markdown summary (the CI PR-comment body) | `coverage/report/SummaryGithub.md` |
| Browsable HTML report | `coverage/report/index.html` |
| Cobertura XML | `coverage/report/Cobertura.xml` |
| Text summary (printed to console) | `coverage/report/Summary.txt` |

**3. Opt-in: post the summary to a PR as a single sticky comment**
So the reliable local coverage can be shared on a PR *without* spending Actions minutes:

```bash
POST_COVERAGE_PR=88 ./scripts/local-ci.sh test
```

- Gated entirely behind `POST_COVERAGE_PR` — **never runs unless you set it**.
- Uses the `gh` CLI. Finds a prior comment by a hidden marker (`<!-- local-ci-coverage -->`) and **edits it** instead of adding a new one, so repeated runs update one sticky comment — same UX as CI's `sticky-pull-request-comment`.
- All posting failures (`gh` missing, not authenticated, network) are **warnings only** — posting can never fail the pipeline.

## Notes

- Script-only change; no product code touched. `coverage/` and `test-results/` are already gitignored, so no artifacts get committed.
- Split out of the #65 diagnostic-report PR (#88), where this tooling change originally rode along.
- Not touched here: trimming the CI workflows themselves to save minutes — that's a separate, riskier change we can consider later.

## Test

- `bash -n scripts/local-ci.sh` — clean.
- Verified `reportgenerator ... -reporttypes:HtmlInline;Cobertura;TextSummary;MarkdownSummaryGithub` against real cobertura output → produced `SummaryGithub.md` (27.3% line / 23.8% branch, 5 assemblies) + HTML + Cobertura.
