### PR TITLE
feature: publish Confuser.MSBuild to GitHub Packages (#54)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,7 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: write
+      packages: write
     env:
       NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages
     steps:
@@ -132,6 +133,21 @@ jobs:
           Get-ChildItem $tmp | Compress-Archive -DestinationPath 'ConfuserEx.zip'
           Remove-Item $tmp -Recurse -Force
           Write-Host "Created ConfuserEx.zip"
+
+      - name: Publish NuGet package to GitHub Packages
+        shell: pwsh
+        run: |
+          $nupkg = Get-ChildItem 'Confuser.MSBuild.Tasks/bin/Release' -Filter '*.nupkg' -ErrorAction SilentlyContinue |
+            Sort-Object LastWriteTime -Descending | Select-Object -First 1
+          if (-not $nupkg) {
+            Write-Host "::warning::No .nupkg found under Confuser.MSBuild.Tasks/bin/Release — skipping package publish."
+            exit 0
+          }
+          Write-Host "Publishing $($nupkg.Name) to GitHub Packages..."
+          dotnet nuget push $nupkg.FullName `
+            --source "https://nuget.pkg.github.com/mcpolo99/index.json" `
+            --api-key "${{ secrets.GITHUB_TOKEN }}" `
+            --skip-duplicate
 
       - name: Configure git identity
         run: |

--- a/docs/building.md
+++ b/docs/building.md
@@ -88,8 +88,10 @@ dispatches the workflow manually from the Actions tab.
 Releases are **not** cut automatically on push to `main`. `release.yml` handles them:
 
 - **Manual** — Actions tab → **release** → **Run workflow** (on `main`). Builds, tags
-  `v<version>`, and publishes a GitHub Release with the CLI/GUI/combined zips and the
-  MSBuild-tasks nupkg. Use the `force` input to release even with no new commits.
+  `v<version>`, publishes a GitHub Release with the CLI/GUI/combined zips and the
+  MSBuild-tasks nupkg, and pushes the `Confuser.MSBuild` package to
+  [GitHub Packages](https://github.com/mcpolo99/ConfuserExx/packages). Use the `force`
+  input to release even with no new commits.
 - **Monthly** — on the 1st of each month a cheap check compares `main` to the last
   `v*` tag and only runs the (expensive) build+publish when there are new commits.
 


### PR DESCRIPTION
Phase 1 of #54 — publish the already-built `Confuser.MSBuild` nupkg to the GitHub Packages NuGet registry.

Fixes #54

## Change
- `release.yml`: added a `dotnet nuget push` step targeting `https://nuget.pkg.github.com/mcpolo99/index.json`, plus `packages: write` on the release job.
- Uses the built-in `GITHUB_TOKEN`; `--skip-duplicate` makes re-runs safe.

## Already in place (no change needed)
- `RepositoryUrl` = mcpolo99/ConfuserExx, full package metadata, and `GeneratePackageOnBuild` were already set — the nupkg is produced and attached to releases today.
- Its blocker #52 (.NET 10 retarget) is done.

## Verified
- `release.yml` YAML valid; local Release build of Confuser.MSBuild.Tasks produces the nupkg at the exact path the push step reads.

## Remaining (separate phases, not this PR)
- Phase 2: `ConfuserEx.Core` library package. Phase 3: `ConfuserEx.Tool` dotnet global tool.

Publishing happens on the next release run (`[skip ci]` here — YAML + docs only).