### PR TITLE
feature: Tier 3 custom Roslyn analyzers CX001–CX004 (#49, #46)

### DIFF
--- a/Confuser.Analyzers/Confuser.Analyzers.csproj
+++ b/Confuser.Analyzers/Confuser.Analyzers.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <!-- Roslyn analyzer assembly. Deliberately standalone (does NOT import
+       ConfuserEx.Common.props) — analyzers must be a single netstandard2.0 assembly
+       with no runtime output and no strong-name/multi-target concerns. -->
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <IsPackable>false</IsPackable>
+    <!-- These analyzers ship inside this repo only; they are never consumed as a NuGet package. -->
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <!-- RS2008 (analyzer release tracking) only matters for analyzers shipped as packages. -->
+    <NoWarn>$(NoWarn);RS2008</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/Confuser.Analyzers/DiagnosticIds.cs
+++ b/Confuser.Analyzers/DiagnosticIds.cs
@@ -1,0 +1,21 @@
+﻿namespace Confuser.Analyzers {
+	/// <summary>
+	///     Diagnostic IDs for the ConfuserEx-specific analyzers. Each catches a bug class that has
+	///     actually been fixed in the codebase, to prevent regressions at compile time.
+	/// </summary>
+	internal static class DiagnosticIds {
+		/// <summary>Imports a member from the host runtime instead of the target's corlib.</summary>
+		public const string HostRuntimeImport = "CX001";
+
+		/// <summary><c>ResolveTypeDef()</c>/<c>ResolveMethodDef()</c> used without a null check.</summary>
+		public const string UnguardedResolve = "CX002";
+
+		/// <summary>Usage of a <c>...Throw</c> resolve helper (audit / awareness).</summary>
+		public const string ResolveThrowAudit = "CX003";
+
+		/// <summary><c>GetTypes()</c> without handling <c>ReflectionTypeLoadException</c>.</summary>
+		public const string UnhandledReflectionTypeLoad = "CX004";
+
+		public const string Category = "ConfuserEx";
+	}
+}

--- a/Confuser.Analyzers/HostRuntimeImportAnalyzer.cs
+++ b/Confuser.Analyzers/HostRuntimeImportAnalyzer.cs
@@ -1,0 +1,64 @@
+﻿using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Confuser.Analyzers {
+	/// <summary>
+	///     CX001 — flags <c>Import(...)</c> whose argument is a member resolved via reflection on
+	///     the host runtime (<c>someType.GetMethod(...)</c>, <c>GetConstructor</c>, <c>GetField</c>,
+	///     <c>GetProperty</c> where the receiver is a <see cref="System.Type" />). Importing a
+	///     host-runtime member into a target module produces a reference to the wrong corlib
+	///     (e.g. the obfuscator's .NET rather than the target's), which breaks the protected
+	///     assembly. Resolve the member through the target module's corlib instead.
+	/// </summary>
+	[DiagnosticAnalyzer(LanguageNames.CSharp)]
+	public sealed class HostRuntimeImportAnalyzer : DiagnosticAnalyzer {
+		static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+			DiagnosticIds.HostRuntimeImport,
+			"Importing a member resolved via host reflection",
+			"Import() argument is resolved with Type.{0}() on the host runtime; resolve the member through the target module's corlib to avoid a wrong-corlib reference",
+			DiagnosticIds.Category,
+			DiagnosticSeverity.Warning,
+			isEnabledByDefault: true,
+			description: "Importing a System.Reflection member (from Type.GetMethod/GetConstructor/GetField/" +
+				"GetProperty) into a dnlib module references the obfuscator's runtime corlib rather than the " +
+				"target's, producing a broken assembly. Resolve the member through the target module's corlib.");
+
+		static readonly ImmutableHashSet<string> ReflectionGetters =
+			ImmutableHashSet.Create("GetMethod", "GetConstructor", "GetField", "GetProperty");
+
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+		public override void Initialize(AnalysisContext context) {
+			context.EnableConcurrentExecution();
+			context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+			context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.InvocationExpression);
+		}
+
+		static void Analyze(SyntaxNodeAnalysisContext context) {
+			var invocation = (InvocationExpressionSyntax)context.Node;
+			if (invocation.Expression is not MemberAccessExpressionSyntax member ||
+				member.Name.Identifier.ValueText != "Import")
+				return;
+
+			foreach (var argument in invocation.ArgumentList.Arguments) {
+				if (argument.Expression is not InvocationExpressionSyntax inner ||
+					inner.Expression is not MemberAccessExpressionSyntax innerMember)
+					continue;
+
+				var getterName = innerMember.Name.Identifier.ValueText;
+				if (!ReflectionGetters.Contains(getterName))
+					continue;
+
+				if (context.SemanticModel.GetSymbolInfo(inner, context.CancellationToken).Symbol is not IMethodSymbol getter ||
+					getter.ContainingType?.ToDisplayString() != "System.Type")
+					continue;
+
+				context.ReportDiagnostic(Diagnostic.Create(Rule, innerMember.Name.GetLocation(), getterName));
+				return;
+			}
+		}
+	}
+}

--- a/Confuser.Analyzers/ResolveThrowAuditAnalyzer.cs
+++ b/Confuser.Analyzers/ResolveThrowAuditAnalyzer.cs
@@ -1,0 +1,54 @@
+﻿using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Confuser.Analyzers {
+	/// <summary>
+	///     CX003 — an awareness/audit rule that surfaces every call to a dnlib <c>Resolve…Throw</c>
+	///     helper (<c>ResolveThrow</c>, <c>ResolveTypeDefThrow</c>, <c>ResolveMethodDefThrow</c>,
+	///     <c>ResolveFieldThrow</c>). These throw when a reference cannot be resolved, which crashes
+	///     obfuscation on assemblies with external/unresolvable members. Most uses are intentional;
+	///     this reports at <see cref="DiagnosticSeverity.Info" /> so the spots can be evaluated
+	///     without adding build noise.
+	/// </summary>
+	[DiagnosticAnalyzer(LanguageNames.CSharp)]
+	public sealed class ResolveThrowAuditAnalyzer : DiagnosticAnalyzer {
+		static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+			DiagnosticIds.ResolveThrowAudit,
+			"Throwing resolve helper used",
+			"'{0}' throws when resolution fails; confirm the target is always resolvable or prefer the non-throwing overload with a null check",
+			DiagnosticIds.Category,
+			DiagnosticSeverity.Info,
+			isEnabledByDefault: true,
+			description: "dnlib's Resolve...Throw helpers throw when a type/member reference cannot be " +
+				"resolved. This surfaces each usage for review; external or unresolvable references should " +
+				"use the non-throwing Resolve... overload with a null check instead.");
+
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+		public override void Initialize(AnalysisContext context) {
+			context.EnableConcurrentExecution();
+			context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+			context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.InvocationExpression);
+		}
+
+		static void Analyze(SyntaxNodeAnalysisContext context) {
+			var invocation = (InvocationExpressionSyntax)context.Node;
+			if (invocation.Expression is not MemberAccessExpressionSyntax member)
+				return;
+
+			var name = member.Name.Identifier.ValueText;
+			if (!IsResolveThrowName(name))
+				return;
+
+			context.ReportDiagnostic(Diagnostic.Create(Rule, member.Name.GetLocation(), name));
+		}
+
+		static bool IsResolveThrowName(string name) =>
+			name.Length > "ResolveThrow".Length - 1 &&
+			name.StartsWith("Resolve", System.StringComparison.Ordinal) &&
+			name.EndsWith("Throw", System.StringComparison.Ordinal);
+	}
+}

--- a/Confuser.Analyzers/UnguardedResolveAnalyzer.cs
+++ b/Confuser.Analyzers/UnguardedResolveAnalyzer.cs
@@ -1,0 +1,76 @@
+﻿using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Confuser.Analyzers {
+	/// <summary>
+	///     CX002 — flags the result of a non-throwing dnlib <c>ResolveTypeDef()</c> /
+	///     <c>ResolveMethodDef()</c> being dereferenced immediately, with no null check. Those
+	///     methods return <c>null</c> for external or unresolvable references, so a direct
+	///     dereference crashes with a <see cref="System.NullReferenceException" /> on assemblies
+	///     that reference types outside the obfuscation set.
+	/// </summary>
+	/// <remarks>
+	///     Only a genuine dereference of the result is flagged — <c>x.ResolveTypeDef().Member</c> or
+	///     <c>x.ResolveMethodDef()[i]</c>. A null-conditional (<c>?.</c>), an assignment, a
+	///     <c>return</c>, or passing the result as an argument (e.g. to dnlib's null-tolerant
+	///     <c>SigComparer.Equals</c>) is not a crash and is intentionally not reported.
+	/// </remarks>
+	[DiagnosticAnalyzer(LanguageNames.CSharp)]
+	public sealed class UnguardedResolveAnalyzer : DiagnosticAnalyzer {
+		static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+			DiagnosticIds.UnguardedResolve,
+			"Resolve result dereferenced without a null check",
+			"'{0}()' returns null for unresolvable references; check the result for null before dereferencing it",
+			DiagnosticIds.Category,
+			DiagnosticSeverity.Warning,
+			isEnabledByDefault: true,
+			description: "dnlib's ResolveTypeDef()/ResolveMethodDef() return null when a reference cannot be " +
+				"resolved (external or unresolvable types). Dereferencing the result directly crashes obfuscation " +
+				"on such assemblies; guard it with a null check or the null-conditional operator.");
+
+		static readonly ImmutableHashSet<string> ResolveMethods =
+			ImmutableHashSet.Create("ResolveTypeDef", "ResolveMethodDef");
+
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+		public override void Initialize(AnalysisContext context) {
+			context.EnableConcurrentExecution();
+			context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+			context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.InvocationExpression);
+		}
+
+		static void Analyze(SyntaxNodeAnalysisContext context) {
+			var invocation = (InvocationExpressionSyntax)context.Node;
+			if (invocation.Expression is not MemberAccessExpressionSyntax member ||
+				!ResolveMethods.Contains(member.Name.Identifier.ValueText) ||
+				invocation.ArgumentList.Arguments.Count != 0)
+				return;
+
+			if (!IsImmediatelyDereferenced(invocation))
+				return;
+
+			context.ReportDiagnostic(Diagnostic.Create(Rule, member.Name.GetLocation(),
+				member.Name.Identifier.ValueText));
+		}
+
+		/// <summary>
+		///     Returns <c>true</c> only when <paramref name="invocation" /> is the receiver of a
+		///     plain member access or element access — i.e. its result is dereferenced right away
+		///     without a null guard. A null-conditional access makes the parent a
+		///     <see cref="ConditionalAccessExpressionSyntax" />, which is safe and returns false.
+		/// </summary>
+		static bool IsImmediatelyDereferenced(InvocationExpressionSyntax invocation) {
+			switch (invocation.Parent) {
+				case MemberAccessExpressionSyntax parentMember when parentMember.Expression == invocation:
+					return true;
+				case ElementAccessExpressionSyntax parentElement when parentElement.Expression == invocation:
+					return true;
+				default:
+					return false;
+			}
+		}
+	}
+}

--- a/Confuser.Analyzers/UnhandledReflectionTypeLoadAnalyzer.cs
+++ b/Confuser.Analyzers/UnhandledReflectionTypeLoadAnalyzer.cs
@@ -1,0 +1,104 @@
+﻿using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Confuser.Analyzers {
+	/// <summary>
+	///     CX004 — flags <c>Assembly.GetTypes()</c> / <c>Module.GetTypes()</c> that are not guarded
+	///     against <see cref="System.Reflection.ReflectionTypeLoadException" />. That exception is
+	///     thrown whenever a contained type cannot be loaded (common for plugin assemblies with
+	///     unresolved dependencies) and caused packer/plugin startup crashes.
+	/// </summary>
+	[DiagnosticAnalyzer(LanguageNames.CSharp)]
+	public sealed class UnhandledReflectionTypeLoadAnalyzer : DiagnosticAnalyzer {
+		static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+			DiagnosticIds.UnhandledReflectionTypeLoad,
+			"GetTypes() without ReflectionTypeLoadException handling",
+			"'{0}.GetTypes()' can throw ReflectionTypeLoadException when a contained type is unresolvable; wrap it in a try/catch",
+			DiagnosticIds.Category,
+			DiagnosticSeverity.Warning,
+			isEnabledByDefault: true,
+			description: "Assembly.GetTypes() and Module.GetTypes() throw ReflectionTypeLoadException when any " +
+				"contained type cannot be loaded. Guard the call (and prefer ex.Types on the exception) to avoid " +
+				"startup crashes when loading plugin or external assemblies.");
+
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+		public override void Initialize(AnalysisContext context) {
+			context.EnableConcurrentExecution();
+			context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+			context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.InvocationExpression);
+		}
+
+		static void Analyze(SyntaxNodeAnalysisContext context) {
+			var invocation = (InvocationExpressionSyntax)context.Node;
+			if (invocation.Expression is not MemberAccessExpressionSyntax member ||
+				member.Name.Identifier.ValueText != "GetTypes")
+				return;
+
+			if (context.SemanticModel.GetSymbolInfo(invocation, context.CancellationToken).Symbol is not IMethodSymbol method ||
+				method.Name != "GetTypes" || !method.Parameters.IsEmpty)
+				return;
+
+			var containingType = method.ContainingType?.ToDisplayString();
+			if (containingType != "System.Reflection.Assembly" && containingType != "System.Reflection.Module")
+				return;
+
+			var rtle = context.Compilation.GetTypeByMetadataName("System.Reflection.ReflectionTypeLoadException");
+			if (IsGuarded(invocation, context.SemanticModel, rtle, context.CancellationToken))
+				return;
+
+			context.ReportDiagnostic(Diagnostic.Create(Rule, member.Name.GetLocation(), containingType));
+		}
+
+		static bool IsGuarded(SyntaxNode node, SemanticModel model, INamedTypeSymbol? rtle, System.Threading.CancellationToken ct) {
+			for (var current = node.Parent; current != null; current = current.Parent) {
+				if (current is TryStatementSyntax tryStmt &&
+					tryStmt.Block.Span.Contains(node.Span) &&
+					CatchesReflectionTypeLoad(tryStmt, model, rtle, ct))
+					return true;
+
+				// Do not walk past the enclosing method / lambda / local-function boundary.
+				if (current is BaseMethodDeclarationSyntax ||
+					current is AnonymousFunctionExpressionSyntax ||
+					current is LocalFunctionStatementSyntax)
+					break;
+			}
+
+			return false;
+		}
+
+		static bool CatchesReflectionTypeLoad(TryStatementSyntax tryStmt, SemanticModel model, INamedTypeSymbol? rtle,
+			System.Threading.CancellationToken ct) {
+			foreach (var clause in tryStmt.Catches) {
+				// A general 'catch { }' (no declared type) catches everything.
+				if (clause.Declaration is null)
+					return true;
+
+				var caught = model.GetTypeInfo(clause.Declaration.Type, ct).Type as INamedTypeSymbol;
+				if (caught is null)
+					continue;
+
+				// The catch guards the call if ReflectionTypeLoadException is assignable to the caught
+				// type (i.e. the caught type is RTLE or one of its base types such as SystemException /
+				// Exception). If we cannot resolve RTLE, fall back to name matching on the base chain.
+				if (rtle is not null) {
+					for (var t = rtle; t is not null; t = t.BaseType) {
+						if (SymbolEqualityComparer.Default.Equals(t, caught))
+							return true;
+					}
+				}
+				else {
+					var name = caught.ToDisplayString();
+					if (name == "System.Exception" || name == "System.SystemException" ||
+						name == "System.Reflection.ReflectionTypeLoadException")
+						return true;
+				}
+			}
+
+			return false;
+		}
+	}
+}

--- a/Confuser.Core/PluginDiscovery.cs
+++ b/Confuser.Core/PluginDiscovery.cs
@@ -55,8 +55,18 @@ namespace Confuser.Core {
 		protected static void AddPlugins(
 			ConfuserContext context, IList<Protection> protections, IList<Packer> packers,
 			IList<ConfuserComponent> components, Assembly asm) {
-			foreach (var module in asm.GetLoadedModules())
-				foreach (var i in module.GetTypes()) {
+			foreach (var module in asm.GetLoadedModules()) {
+				Type[] moduleTypes;
+				try {
+					moduleTypes = module.GetTypes();
+				}
+				catch (ReflectionTypeLoadException ex) {
+					// A plugin assembly may reference dependencies that are not present; keep the
+					// types that did load instead of crashing plugin discovery.
+					moduleTypes = Array.FindAll(ex.Types, t => t != null);
+				}
+
+				foreach (var i in moduleTypes) {
 					if (i.IsAbstract || !HasAccessibleDefConstructor(i))
 						continue;
 
@@ -85,6 +95,7 @@ namespace Confuser.Core {
 						}
 					}
 				}
+			}
 			context.CheckCancellation();
 		}
 

--- a/Confuser.Protections/Utils.cs
+++ b/Confuser.Protections/Utils.cs
@@ -12,7 +12,15 @@ namespace Confuser.Protections {
 		public static IMethod Import(this ModuleDef module, ConfuserContext context, Type classType, string method) {
 			var corLib = context.Resolver.Resolve(context.CurrentModule?.CorLibTypes.AssemblyRef, context.CurrentModule);
 			var typeInfo = corLib?.ManifestModule.Find(classType.FullName, true);
-			return (typeInfo == null) ? module.Import(classType.GetMethod(method)) : module.Import(typeInfo.FindMethod(method));
+			if (typeInfo != null)
+				return module.Import(typeInfo.FindMethod(method));
+
+			// CX001: intentional last-resort fallback. When the target module's corlib type cannot be
+			// resolved through the context (rare), host reflection is the only available source for the
+			// member reference. New code must resolve through the context instead of copying this.
+#pragma warning disable CX001
+			return module.Import(classType.GetMethod(method));
+#pragma warning restore CX001
 		}
 	}
 }

--- a/Confuser2.sln
+++ b/Confuser2.sln
@@ -205,6 +205,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CrossFramework.WPF.Net8", "
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CrossFramework.Library.Net10", "Tests\CrossFramework.Library.Net10\CrossFramework.Library.Net10.csproj", "{4458415A-0F5E-4136-B723-7A67955D6047}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Confuser.Analyzers", "Confuser.Analyzers\Confuser.Analyzers.csproj", "{886E5FF3-DF94-4C6B-A5C3-E97038B5C275}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Confuser.Analyzers.Test", "Tests\Confuser.Analyzers.Test\Confuser.Analyzers.Test.csproj", "{1B22CAAE-FC4A-478D-BD68-D29A3081F938}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1343,6 +1347,30 @@ Global
 		{4458415A-0F5E-4136-B723-7A67955D6047}.Release|x64.Build.0 = Release|Any CPU
 		{4458415A-0F5E-4136-B723-7A67955D6047}.Release|x86.ActiveCfg = Release|Any CPU
 		{4458415A-0F5E-4136-B723-7A67955D6047}.Release|x86.Build.0 = Release|Any CPU
+		{886E5FF3-DF94-4C6B-A5C3-E97038B5C275}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{886E5FF3-DF94-4C6B-A5C3-E97038B5C275}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{886E5FF3-DF94-4C6B-A5C3-E97038B5C275}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{886E5FF3-DF94-4C6B-A5C3-E97038B5C275}.Debug|x64.Build.0 = Debug|Any CPU
+		{886E5FF3-DF94-4C6B-A5C3-E97038B5C275}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{886E5FF3-DF94-4C6B-A5C3-E97038B5C275}.Debug|x86.Build.0 = Debug|Any CPU
+		{886E5FF3-DF94-4C6B-A5C3-E97038B5C275}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{886E5FF3-DF94-4C6B-A5C3-E97038B5C275}.Release|Any CPU.Build.0 = Release|Any CPU
+		{886E5FF3-DF94-4C6B-A5C3-E97038B5C275}.Release|x64.ActiveCfg = Release|Any CPU
+		{886E5FF3-DF94-4C6B-A5C3-E97038B5C275}.Release|x64.Build.0 = Release|Any CPU
+		{886E5FF3-DF94-4C6B-A5C3-E97038B5C275}.Release|x86.ActiveCfg = Release|Any CPU
+		{886E5FF3-DF94-4C6B-A5C3-E97038B5C275}.Release|x86.Build.0 = Release|Any CPU
+		{1B22CAAE-FC4A-478D-BD68-D29A3081F938}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1B22CAAE-FC4A-478D-BD68-D29A3081F938}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1B22CAAE-FC4A-478D-BD68-D29A3081F938}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1B22CAAE-FC4A-478D-BD68-D29A3081F938}.Debug|x64.Build.0 = Debug|Any CPU
+		{1B22CAAE-FC4A-478D-BD68-D29A3081F938}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1B22CAAE-FC4A-478D-BD68-D29A3081F938}.Debug|x86.Build.0 = Debug|Any CPU
+		{1B22CAAE-FC4A-478D-BD68-D29A3081F938}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1B22CAAE-FC4A-478D-BD68-D29A3081F938}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1B22CAAE-FC4A-478D-BD68-D29A3081F938}.Release|x64.ActiveCfg = Release|Any CPU
+		{1B22CAAE-FC4A-478D-BD68-D29A3081F938}.Release|x64.Build.0 = Release|Any CPU
+		{1B22CAAE-FC4A-478D-BD68-D29A3081F938}.Release|x86.ActiveCfg = Release|Any CPU
+		{1B22CAAE-FC4A-478D-BD68-D29A3081F938}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1434,6 +1462,7 @@ Global
 		{3942E3FD-06BC-470C-A1ED-BB18F2332B94} = {356BDB31-853E-43BB-8F9A-D8AC08F69EBB}
 		{30DC9F52-E08A-4EF0-B041-04AED6135C3D} = {356BDB31-853E-43BB-8F9A-D8AC08F69EBB}
 		{4458415A-0F5E-4136-B723-7A67955D6047} = {356BDB31-853E-43BB-8F9A-D8AC08F69EBB}
+		{1B22CAAE-FC4A-478D-BD68-D29A3081F938} = {356BDB31-853E-43BB-8F9A-D8AC08F69EBB}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {0D937D9E-E04B-4A68-B639-D4260473A388}

--- a/ConfuserEx.Common.targets
+++ b/ConfuserEx.Common.targets
@@ -7,5 +7,15 @@
     <PackageReference Include="Roslynator.Analyzers" Version="4.*" PrivateAssets="all"
 					  Condition="'$(EnableNETAnalyzers)' != 'false'" />
   </ItemGroup>
-  
+
+  <!-- Tier 3: ConfuserEx-specific analyzers (issue #49). Referenced as an analyzer, not a
+       runtime dependency. Excludes the analyzer project itself to avoid a self-reference. -->
+  <ItemGroup Condition="'$(EnableNETAnalyzers)' != 'false' and '$(MSBuildProjectName)' != 'Confuser.Analyzers'">
+    <!-- SkipGetTargetFrameworkProperties bypasses TFM-compatibility negotiation so the
+         netstandard2.0 analyzer can be attached to any target (including net20). -->
+    <ProjectReference Include="$(MSBuildThisFileDirectory)Confuser.Analyzers\Confuser.Analyzers.csproj"
+					  OutputItemType="Analyzer" ReferenceOutputAssembly="false" PrivateAssets="all"
+					  SkipGetTargetFrameworkProperties="true" UndefineProperties="TargetFramework" />
+  </ItemGroup>
+
 </Project>

--- a/ConfuserEx/ComponentDiscovery.cs
+++ b/ConfuserEx/ComponentDiscovery.cs
@@ -11,8 +11,18 @@ namespace ConfuserEx {
 			var alc = new PluginLoadContext(pluginPath);
 			try {
 				Assembly assembly = alc.LoadFromAssemblyPath(pluginPath);
-				foreach (var module in assembly.GetLoadedModules())
-					foreach (var i in module.GetTypes()) {
+				foreach (var module in assembly.GetLoadedModules()) {
+					Type[] moduleTypes;
+					try {
+						moduleTypes = module.GetTypes();
+					}
+					catch (ReflectionTypeLoadException ex) {
+						// A plugin may reference dependencies that are not present; keep the types
+						// that did load instead of crashing component discovery.
+						moduleTypes = Array.FindAll(ex.Types, t => t != null);
+					}
+
+					foreach (var i in moduleTypes) {
 						if (i.IsAbstract || !PluginDiscovery.HasAccessibleDefConstructor(i))
 							continue;
 
@@ -25,6 +35,7 @@ namespace ConfuserEx {
 							AddPacker(packers, Info.FromComponent(packer, pluginPath));
 						}
 					}
+				}
 			}
 			finally {
 				alc.Unload();

--- a/Tests/Confuser.Analyzers.Test/Confuser.Analyzers.Test.csproj
+++ b/Tests/Confuser.Analyzers.Test/Confuser.Analyzers.Test.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Match the Roslyn version the analyzer is built against to avoid CS1705. -->
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Confuser.Analyzers\Confuser.Analyzers.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Tests/Confuser.Analyzers.Test/HostRuntimeImportAnalyzerTest.cs
+++ b/Tests/Confuser.Analyzers.Test/HostRuntimeImportAnalyzerTest.cs
@@ -1,0 +1,63 @@
+﻿using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Testing;
+using Xunit;
+using Verify = Microsoft.CodeAnalysis.CSharp.Testing.CSharpAnalyzerVerifier<
+	Confuser.Analyzers.HostRuntimeImportAnalyzer,
+	Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
+
+namespace Confuser.Analyzers.Test {
+	public class HostRuntimeImportAnalyzerTest {
+		const string Stub = @"
+using System;
+class Mod { public object Import(object member) => member; }
+";
+
+		[Fact]
+		public async Task Flags_ImportOfTypeVariableGetMethod() {
+			string source = Stub + @"
+class C {
+    void M(Mod mod, Type t) {
+        mod.Import(t.{|#0:GetMethod|}(""X""));
+    }
+}";
+			var expected = Verify.Diagnostic("CX001").WithLocation(0).WithArguments("GetMethod");
+			await Verify.VerifyAnalyzerAsync(source, expected);
+		}
+
+		[Fact]
+		public async Task Flags_ImportOfTypeofGetConstructor() {
+			string source = Stub + @"
+class C {
+    void M(Mod mod) {
+        mod.Import(typeof(string).{|#0:GetConstructor|}(Type.EmptyTypes));
+    }
+}";
+			var expected = Verify.Diagnostic("CX001").WithLocation(0).WithArguments("GetConstructor");
+			await Verify.VerifyAnalyzerAsync(source, expected);
+		}
+
+		[Fact]
+		public async Task DoesNotFlag_ImportOfNonReflectionMember() {
+			// Resolving through a non-System.Type API (the safe path) must not be flagged.
+			string source = Stub + @"
+class Resolved { public object FindMethod(string n) => null; }
+class C {
+    void M(Mod mod, Resolved r) {
+        mod.Import(r.FindMethod(""X""));
+    }
+}";
+			await Verify.VerifyAnalyzerAsync(source);
+		}
+
+		[Fact]
+		public async Task DoesNotFlag_NonImportCall() {
+			string source = Stub + @"
+class C {
+    void M(Type t) {
+        var m = t.GetMethod(""X"");
+    }
+}";
+			await Verify.VerifyAnalyzerAsync(source);
+		}
+	}
+}

--- a/Tests/Confuser.Analyzers.Test/ResolveThrowAuditAnalyzerTest.cs
+++ b/Tests/Confuser.Analyzers.Test/ResolveThrowAuditAnalyzerTest.cs
@@ -1,0 +1,39 @@
+﻿using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Testing;
+using Xunit;
+using Verify = Microsoft.CodeAnalysis.CSharp.Testing.CSharpAnalyzerVerifier<
+	Confuser.Analyzers.ResolveThrowAuditAnalyzer,
+	Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
+
+namespace Confuser.Analyzers.Test {
+	public class ResolveThrowAuditAnalyzerTest {
+		[Theory]
+		[InlineData("ResolveThrow")]
+		[InlineData("ResolveTypeDefThrow")]
+		[InlineData("ResolveMethodDefThrow")]
+		[InlineData("ResolveFieldThrow")]
+		public async Task Flags_ResolveThrowHelpers(string methodName) {
+			string source = @"
+class Ref { public object " + methodName + @"() => null; }
+class C {
+    void M(Ref r) {
+        var x = r.{|#0:" + methodName + @"|}();
+    }
+}";
+			var expected = Verify.Diagnostic("CX003").WithLocation(0).WithArguments(methodName);
+			await Verify.VerifyAnalyzerAsync(source, expected);
+		}
+
+		[Fact]
+		public async Task DoesNotFlag_NonThrowingResolve() {
+			const string source = @"
+class Ref { public object ResolveTypeDef() => null; }
+class C {
+    void M(Ref r) {
+        var x = r.ResolveTypeDef();
+    }
+}";
+			await Verify.VerifyAnalyzerAsync(source);
+		}
+	}
+}

--- a/Tests/Confuser.Analyzers.Test/UnguardedResolveAnalyzerTest.cs
+++ b/Tests/Confuser.Analyzers.Test/UnguardedResolveAnalyzerTest.cs
@@ -1,0 +1,67 @@
+﻿using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Testing;
+using Xunit;
+using Verify = Microsoft.CodeAnalysis.CSharp.Testing.CSharpAnalyzerVerifier<
+	Confuser.Analyzers.UnguardedResolveAnalyzer,
+	Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
+
+namespace Confuser.Analyzers.Test {
+	public class UnguardedResolveAnalyzerTest {
+		const string Stub = @"
+class Def { public int Field; public void Do() {} }
+class Ref {
+    public Def ResolveTypeDef() => null;
+    public Def ResolveMethodDef() => null;
+}
+";
+
+		[Fact]
+		public async Task Flags_ImmediateMemberDereference() {
+			string source = Stub + @"
+class C {
+    void M(Ref r) {
+        r.{|#0:ResolveTypeDef|}().Do();
+    }
+}";
+			var expected = Verify.Diagnostic("CX002").WithLocation(0).WithArguments("ResolveTypeDef");
+			await Verify.VerifyAnalyzerAsync(source, expected);
+		}
+
+		[Fact]
+		public async Task DoesNotFlag_NullConditionalDereference() {
+			string source = Stub + @"
+class C {
+    void M(Ref r) {
+        r.ResolveMethodDef()?.Do();
+    }
+}";
+			await Verify.VerifyAnalyzerAsync(source);
+		}
+
+		[Fact]
+		public async Task DoesNotFlag_AssignmentWithoutDereference() {
+			string source = Stub + @"
+class C {
+    Def M(Ref r) {
+        var d = r.ResolveTypeDef();
+        return d;
+    }
+}";
+			await Verify.VerifyAnalyzerAsync(source);
+		}
+
+		[Fact]
+		public async Task DoesNotFlag_PassedAsArgument() {
+			// Mirrors the real VTableAnalyzer usage: the result is handed to a null-tolerant method,
+			// which is not a dereference and must not be flagged.
+			string source = Stub + @"
+class C {
+    static bool AreEqual(Def a, Def b) => true;
+    void M(Ref r) {
+        var ok = AreEqual(r.ResolveTypeDef(), r.ResolveMethodDef());
+    }
+}";
+			await Verify.VerifyAnalyzerAsync(source);
+		}
+	}
+}

--- a/Tests/Confuser.Analyzers.Test/UnhandledReflectionTypeLoadAnalyzerTest.cs
+++ b/Tests/Confuser.Analyzers.Test/UnhandledReflectionTypeLoadAnalyzerTest.cs
@@ -1,0 +1,66 @@
+﻿using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Testing;
+using Xunit;
+using Verify = Microsoft.CodeAnalysis.CSharp.Testing.CSharpAnalyzerVerifier<
+	Confuser.Analyzers.UnhandledReflectionTypeLoadAnalyzer,
+	Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
+
+namespace Confuser.Analyzers.Test {
+	public class UnhandledReflectionTypeLoadAnalyzerTest {
+		[Fact]
+		public async Task Flags_UnguardedAssemblyGetTypes() {
+			const string source = @"
+using System.Reflection;
+class C {
+    void M(Assembly asm) {
+        var t = asm.{|#0:GetTypes|}();
+    }
+}";
+			var expected = Verify.Diagnostic("CX004")
+				.WithLocation(0)
+				.WithArguments("System.Reflection.Assembly");
+			await Verify.VerifyAnalyzerAsync(source, expected);
+		}
+
+		[Fact]
+		public async Task DoesNotFlag_WhenGuardedByReflectionTypeLoadException() {
+			const string source = @"
+using System;
+using System.Reflection;
+class C {
+    void M(Assembly asm) {
+        try { var t = asm.GetTypes(); }
+        catch (ReflectionTypeLoadException) { }
+    }
+}";
+			await Verify.VerifyAnalyzerAsync(source);
+		}
+
+		[Fact]
+		public async Task DoesNotFlag_WhenGuardedByBaseException() {
+			const string source = @"
+using System;
+using System.Reflection;
+class C {
+    void M(Assembly asm) {
+        try { var t = asm.GetTypes(); }
+        catch (Exception) { }
+    }
+}";
+			await Verify.VerifyAnalyzerAsync(source);
+		}
+
+		[Fact]
+		public async Task DoesNotFlag_UnrelatedGetTypesMethod() {
+			// A GetTypes() on a non-reflection type must not be flagged.
+			const string source = @"
+class Other { public int[] GetTypes() => new int[0]; }
+class C {
+    void M(Other o) {
+        var t = o.GetTypes();
+    }
+}";
+			await Verify.VerifyAnalyzerAsync(source);
+		}
+	}
+}


### PR DESCRIPTION
Implements the Tier 3 ConfuserEx-specific analyzers — all four rules — completing #49. With #46's Tier 1 (built-in analyzers) and Tier 2 (Roslynator) already wired, this also finishes #46.

Closes #49
Closes #46

## New: `Confuser.Analyzers` project
A netstandard2.0 Roslyn analyzer assembly wired into every project via `ConfuserEx.Common.targets` (`SkipGetTargetFrameworkProperties` + `UndefineProperties` so it attaches even to the net20 runtime).

## The four rules

| ID | Rule | Severity | Violations fixed |
|----|------|----------|------------------|
| **CX004** | `Assembly/Module.GetTypes()` without `ReflectionTypeLoadException` handling | Warning | 2 (PluginDiscovery, ComponentDiscovery) |
| **CX003** | `Resolve...Throw` audit | Info | 0 (awareness; ~34 intentional uses, no build noise) |
| **CX002** | `ResolveTypeDef()/ResolveMethodDef()` result dereferenced without a null check | Warning | 0 (pure prevention) |
| **CX001** | `Import(Type.GetMethod/GetConstructor/...)` — host-reflection import (wrong-corlib) | Warning | 1 (Utils.cs fallback, documented + suppressed) |

## Design notes (the issue was partly stale — verified against current code)
- **CX004** resolves the invocation symbol so it only fires for `System.Reflection` types — dnlib's `ModuleDef.GetTypes()` (returns TypeDef, never throws) is correctly ignored.
- **CX002** flags only genuine dereferences. The VTableAnalyzer sites the issue listed pass results to dnlib's null-tolerant `SigComparer.Equals` — not a crash — so they are correctly **not** flagged (no false positive).
- **CX001** was redesigned: the issue's three call sites were already refactored to a context-aware `Import(context, Type, method)` helper. The only remaining host-reflection path is that helper's last-resort fallback, which CX001 now targets; it's isolated and suppressed with a documented pragma.

## Tests & verification
- **17 analyzer unit tests** (Microsoft.CodeAnalysis.Testing) covering fire/no-fire for every rule.
- Full solution builds clean with all analyzers wired — **zero CX diagnostics** (violations fixed/suppressed).

Develop PRs are gated, so nothing runs automatically; validated locally.