### PR TITLE
feature: symbol map reuse for consistent re-obfuscation (#26)

### DIFF
--- a/Confuser.CLI/Program.cs
+++ b/Confuser.CLI/Program.cs
@@ -28,6 +28,7 @@ namespace Confuser.CLI {
 				bool quiet = false;
 				bool dumpRequested = false;
 				string dumpPath = null;
+				string inputMap = null;
 				int verbosity = 0;
 				string outDir = null;
 				string snKeyPath = null;
@@ -65,6 +66,9 @@ namespace Confuser.CLI {
 					}, {
 						"dump:", "write a diagnostic report (optionally to the given file).",
 						value => { dumpRequested = true; if (!string.IsNullOrEmpty(value)) dumpPath = value; }
+					}, {
+						"map=", "reuse names from a previous symbol map for consistent re-obfuscation.",
+						value => { inputMap = value; }
 					}
 				};
 
@@ -146,6 +150,9 @@ namespace Confuser.CLI {
 					proj.Debug = debug;
 					parameters.Project = proj;
 				}
+
+				if (inputMap != null && parameters.Project != null)
+					parameters.Project.InputSymbolMap = inputMap;
 
 				int retVal = RunProject(parameters, quiet, verbosity, dumpRequested, dumpPath);
 
@@ -284,6 +291,7 @@ namespace Confuser.CLI {
 			WriteLine("    -v|verbose : increase verbosity (-v debug, -vv trace).");
 			WriteLine("    -q|quiet   : only show warnings and errors.");
 			WriteLine("    -dump      : write a diagnostic report (-dump=<file> for a custom path).");
+			WriteLine("    -map       : reuse names from a previous symbol map for consistent re-obfuscation.");
 		}
 
 		static void WriteLineWithColor(ConsoleColor color, string txt) {

--- a/Confuser.Core/Project/ConfuserPrj.xsd
+++ b/Confuser.Core/Project/ConfuserPrj.xsd
@@ -75,6 +75,7 @@
       <xs:attribute name="baseDir" type="xs:string" use="required" />
       <xs:attribute name="seed" type="xs:string" use="optional" />
       <xs:attribute name="debug" type="xs:boolean" default="false" />
+      <xs:attribute name="inputSymbolMap" type="xs:string" use="optional" />
     </xs:complexType>
   </xs:element>
 </xs:schema>

--- a/Confuser.Core/Project/ConfuserProject.cs
+++ b/Confuser.Core/Project/ConfuserProject.cs
@@ -529,6 +529,14 @@ namespace Confuser.Core.Project {
 		public bool Debug { get; set; }
 
 		/// <summary>
+		///     Gets or sets the path to a symbol map from a previous obfuscation run. When set, the
+		///     renamer reuses the obfuscated names recorded in that map, so re-obfuscation produces
+		///     consistent names across builds (e.g. to patch already-deployed obfuscated assemblies).
+		/// </summary>
+		/// <value>The path to the input symbol map, or <c>null</c> to generate fresh names.</value>
+		public string InputSymbolMap { get; set; }
+
+		/// <summary>
 		///     Gets or sets the output directory.
 		/// </summary>
 		/// <value>The output directory.</value>
@@ -594,6 +602,12 @@ namespace Confuser.Core.Project {
 				elem.Attributes.Append(debugAttr);
 			}
 
+			if (InputSymbolMap != null) {
+				XmlAttribute mapAttr = xmlDoc.CreateAttribute("inputSymbolMap");
+				mapAttr.Value = InputSymbolMap;
+				elem.Attributes.Append(mapAttr);
+			}
+
 			foreach (Rule i in Rules)
 				elem.AppendChild(i.Save(xmlDoc));
 
@@ -654,6 +668,11 @@ namespace Confuser.Core.Project {
 				Debug = bool.Parse(docElem.Attributes["debug"].Value);
 			else
 				Debug = false;
+
+			if (docElem.Attributes["inputSymbolMap"] != null)
+				InputSymbolMap = docElem.Attributes["inputSymbolMap"].Value.NullIfEmpty();
+			else
+				InputSymbolMap = null;
 
 			Packer = null;
 			Clear();
@@ -724,6 +743,7 @@ namespace Confuser.Core.Project {
 			var ret = new ConfuserProject();
 			ret.Seed = Seed;
 			ret.Debug = Debug;
+			ret.InputSymbolMap = InputSymbolMap;
 			ret.OutputDirectory = OutputDirectory;
 			ret.BaseDirectory = BaseDirectory;
 			ret.Packer = Packer == null ? null : Packer.Clone();

--- a/Confuser.Renamer/NameService.cs
+++ b/Confuser.Renamer/NameService.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Text;
 using Confuser.Core;
@@ -8,6 +9,7 @@ using Confuser.Core.Services;
 using Confuser.Renamer.Analyzers;
 using Confuser.Renamer.Properties;
 using dnlib.DotNet;
+using Microsoft.Extensions.Logging;
 
 namespace Confuser.Renamer {
 	public interface INameService {
@@ -67,6 +69,7 @@ namespace Confuser.Renamer {
 		readonly Dictionary<string, string> _originalToObfuscatedNameMap = new Dictionary<string, string>();
 		readonly Dictionary<string, string> _obfuscatedToOriginalNameMap = new Dictionary<string, string>();
 		readonly Dictionary<string, string> _prefixesMap = new Dictionary<string, string>();
+		readonly bool hasInputMap;
 		internal ReversibleRenamer reversibleRenamer;
 
 		public NameService(ConfuserContext context) {
@@ -74,6 +77,7 @@ namespace Confuser.Renamer {
 			storage = new VTableStorage(context.Logger);
 			random = context.Registry.GetService<IRandomService>().GetRandomGenerator(NameProtection._FullId);
 			nameSeed = random.NextBytes(20);
+			hasInputMap = LoadInputSymbolMap();
 
 			Renamers = new List<IRenamer> {
 				new InterReferenceAnalyzer(),
@@ -88,6 +92,57 @@ namespace Confuser.Renamer {
 		}
 
 		public IList<IRenamer> Renamers { get; private set; }
+
+		/// <summary>
+		///     Loads the project's input symbol map (if any) so previously assigned obfuscated names
+		///     are reused, giving consistent names across re-obfuscation runs. The file uses the same
+		///     "{obfuscated}\t{original}" format as the exported <c>symbols.map</c>.
+		/// </summary>
+		/// <returns><c>true</c> if a non-empty map was loaded; otherwise <c>false</c>.</returns>
+		bool LoadInputSymbolMap() {
+			var mapPath = context.Project.InputSymbolMap;
+			if (string.IsNullOrEmpty(mapPath))
+				return false;
+
+			try {
+				if (!Path.IsPathRooted(mapPath))
+					mapPath = Path.Combine(context.BaseDirectory, mapPath);
+
+				if (!File.Exists(mapPath)) {
+					context.Logger.LogWarning("Input symbol map not found: '{0}'. Names will be generated fresh.", mapPath);
+					return false;
+				}
+
+				int count = 0;
+				foreach (var line in File.ReadAllLines(mapPath)) {
+					if (string.IsNullOrWhiteSpace(line))
+						continue;
+
+					int tab = line.IndexOf('\t');
+					if (tab <= 0)
+						continue;
+
+					var obfuscated = line.Substring(0, tab);
+					var original = line.Substring(tab + 1);
+
+					// The map is "{obfuscated}\t{original}"; reuse looks up original -> obfuscated.
+					if (!_obfuscatedToOriginalNameMap.ContainsKey(obfuscated))
+						_obfuscatedToOriginalNameMap[obfuscated] = original;
+					if (!_originalToObfuscatedNameMap.ContainsKey(original)) {
+						_originalToObfuscatedNameMap[original] = obfuscated;
+						count++;
+					}
+				}
+
+				context.Logger.LogInformation(
+					"Loaded {0} name mappings from input symbol map for consistent re-obfuscation.", count);
+				return count > 0;
+			}
+			catch (Exception ex) {
+				context.Logger.LogWarning(ex, "Failed to load input symbol map. Names will be generated fresh.");
+				return false;
+			}
+		}
 
 		public VTableStorage GetVTables() {
 			return storage;
@@ -255,7 +310,10 @@ namespace Confuser.Renamer {
 					hash = Utils.SHA1(hash);
 				}
 
-				if (mode == RenameMode.Decodable || mode == RenameMode.Sequential) {
+				// Decodable/Sequential always record the mapping (they need it to be reversible).
+				// When an input symbol map is in use, record every mode so newly-generated names are
+				// reused on the next run and the exported map stays complete and chainable.
+				if (mode == RenameMode.Decodable || mode == RenameMode.Sequential || hasInputMap) {
 					_obfuscatedToOriginalNameMap.Add(newName, name);
 					_originalToObfuscatedNameMap.Add(name, newName);
 				}

--- a/Confuser2.sln
+++ b/Confuser2.sln
@@ -211,6 +211,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Confuser.Analyzers.Test", "
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AntiDebug.Test", "Tests\AntiDebug.Test\AntiDebug.Test.csproj", "{47197200-B8CB-400A-B1BD-84975FEC8C28}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SymbolMapReuse.Test", "Tests\SymbolMapReuse.Test\SymbolMapReuse.Test.csproj", "{591069EF-617C-4284-A968-5DB55BE1E1EF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1385,6 +1387,18 @@ Global
 		{47197200-B8CB-400A-B1BD-84975FEC8C28}.Release|x64.Build.0 = Release|Any CPU
 		{47197200-B8CB-400A-B1BD-84975FEC8C28}.Release|x86.ActiveCfg = Release|Any CPU
 		{47197200-B8CB-400A-B1BD-84975FEC8C28}.Release|x86.Build.0 = Release|Any CPU
+		{591069EF-617C-4284-A968-5DB55BE1E1EF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{591069EF-617C-4284-A968-5DB55BE1E1EF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{591069EF-617C-4284-A968-5DB55BE1E1EF}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{591069EF-617C-4284-A968-5DB55BE1E1EF}.Debug|x64.Build.0 = Debug|Any CPU
+		{591069EF-617C-4284-A968-5DB55BE1E1EF}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{591069EF-617C-4284-A968-5DB55BE1E1EF}.Debug|x86.Build.0 = Debug|Any CPU
+		{591069EF-617C-4284-A968-5DB55BE1E1EF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{591069EF-617C-4284-A968-5DB55BE1E1EF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{591069EF-617C-4284-A968-5DB55BE1E1EF}.Release|x64.ActiveCfg = Release|Any CPU
+		{591069EF-617C-4284-A968-5DB55BE1E1EF}.Release|x64.Build.0 = Release|Any CPU
+		{591069EF-617C-4284-A968-5DB55BE1E1EF}.Release|x86.ActiveCfg = Release|Any CPU
+		{591069EF-617C-4284-A968-5DB55BE1E1EF}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1478,6 +1492,7 @@ Global
 		{4458415A-0F5E-4136-B723-7A67955D6047} = {356BDB31-853E-43BB-8F9A-D8AC08F69EBB}
 		{1B22CAAE-FC4A-478D-BD68-D29A3081F938} = {356BDB31-853E-43BB-8F9A-D8AC08F69EBB}
 		{47197200-B8CB-400A-B1BD-84975FEC8C28} = {356BDB31-853E-43BB-8F9A-D8AC08F69EBB}
+		{591069EF-617C-4284-A968-5DB55BE1E1EF} = {356BDB31-853E-43BB-8F9A-D8AC08F69EBB}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {0D937D9E-E04B-4A68-B639-D4260473A388}

--- a/ConfuserEx/ViewModel/Project/ProjectVM.cs
+++ b/ConfuserEx/ViewModel/Project/ProjectVM.cs
@@ -57,6 +57,11 @@ namespace ConfuserEx.ViewModel {
 			set { SetProperty(proj.Debug != value, val => proj.Debug = val, value, "Debug"); }
 		}
 
+		public string InputSymbolMap {
+			get { return proj.InputSymbolMap; }
+			set { SetProperty(proj.InputSymbolMap != value, val => proj.InputSymbolMap = val, value, "InputSymbolMap"); }
+		}
+
 		public string BaseDirectory {
 			get { return proj.BaseDirectory; }
 			set { SetProperty(proj.BaseDirectory != value, val => proj.BaseDirectory = val, value, "BaseDirectory"); }

--- a/ConfuserEx/Views/ProjectTabAdvancedView.xaml
+++ b/ConfuserEx/Views/ProjectTabAdvancedView.xaml
@@ -13,14 +13,33 @@
         </Grid.ColumnDefinitions>
         <Grid.RowDefinitions>
             <RowDefinition Height="36px" />
+            <RowDefinition Height="36px" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
 
-        <Label Grid.Row="0" Grid.Column="0" Content="Probe Paths :" Margin="5" VerticalAlignment="Center" />
-        <ListBox Grid.Row="1" Grid.Column="0" Margin="5" x:Name="ProbePaths" ItemsSource="{Binding ProbePaths}"
+        <Grid Grid.Row="0" Grid.ColumnSpan="4">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="120px" />
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="36px" />
+            </Grid.ColumnDefinitions>
+            <Label Grid.Column="0" Content="Input Symbol Map :" Margin="5" HorizontalContentAlignment="Right"
+                   VerticalContentAlignment="Center" />
+            <TextBox Grid.Column="1" Margin="5" VerticalContentAlignment="Center"
+                     Text="{Binding InputSymbolMap, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                     local:Skin.EmptyPrompt="Reuse a previous symbols.map for consistent re-obfuscation"
+                     local:FileDragDrop.Command="{x:Static local:FileDragDrop.FileCmd}" />
+            <Button Grid.Column="2" Margin="5" VerticalAlignment="Center" Height="26" x:Name="ChooseSymbolMap">
+                <TextBlock FontSize="14px" FontFamily="{DynamicResource FontAwesome}" Text="&#xf141;" Height="10px"
+                           TextOptions.TextRenderingMode="GrayScale" />
+            </Button>
+        </Grid>
+
+        <Label Grid.Row="1" Grid.Column="0" Content="Probe Paths :" Margin="5" VerticalAlignment="Center" />
+        <ListBox Grid.Row="2" Grid.Column="0" Margin="5" x:Name="ProbePaths" ItemsSource="{Binding ProbePaths}"
                  local:FileDragDrop.Command="{x:Static local:FileDragDrop.DirectoryCmd}"
                  ScrollViewer.CanContentScroll="False" />
-        <StackPanel Grid.Row="1" Grid.Column="1">
+        <StackPanel Grid.Row="2" Grid.Column="1">
             <Button Height="26" Margin="5" DockPanel.Dock="Top" x:Name="AddProbe">
                 <TextBlock FontSize="14px" FontFamily="{DynamicResource FontAwesome}" Text="&#xf067;" Height="12px"
                            TextOptions.TextRenderingMode="GrayScale" />
@@ -31,11 +50,11 @@
             </Button>
         </StackPanel>
 
-        <Label Grid.Row="0" Grid.Column="2" Content="Plugins :" Margin="5" VerticalAlignment="Center" />
-        <ListBox Grid.Row="1" Grid.Column="2" Margin="5" x:Name="PluginPaths" ItemsSource="{Binding Plugins}"
+        <Label Grid.Row="1" Grid.Column="2" Content="Plugins :" Margin="5" VerticalAlignment="Center" />
+        <ListBox Grid.Row="2" Grid.Column="2" Margin="5" x:Name="PluginPaths" ItemsSource="{Binding Plugins}"
                  local:FileDragDrop.Command="{x:Static local:FileDragDrop.FileCmd}"
                  ScrollViewer.CanContentScroll="False" />
-        <StackPanel Grid.Row="1" Grid.Column="3">
+        <StackPanel Grid.Row="2" Grid.Column="3">
             <Button Height="26" Margin="5" DockPanel.Dock="Top" x:Name="AddPlugin">
                 <TextBlock FontSize="14px" FontFamily="{DynamicResource FontAwesome}" Text="&#xf067;" Height="12px"
                            TextOptions.TextRenderingMode="GrayScale" />

--- a/ConfuserEx/Views/ProjectTabAdvancedView.xaml.cs
+++ b/ConfuserEx/Views/ProjectTabAdvancedView.xaml.cs
@@ -18,6 +18,13 @@ namespace ConfuserEx.Views {
 		public override void OnApplyTemplate() {
 			base.OnApplyTemplate();
 
+			ChooseSymbolMap.Command = new RelayCommand(() => {
+				var ofd = new VistaOpenFileDialog();
+				ofd.Filter = "Symbol map (*.map)|*.map|All Files (*.*)|*.*";
+				if (ofd.ShowDialog() ?? false)
+					project.InputSymbolMap = ofd.FileName;
+			});
+
 			AddPlugin.Command = new RelayCommand(() => {
 				var ofd = new VistaOpenFileDialog();
 				ofd.Filter = ".NET assemblies (*.exe, *.dll)|*.exe;*.dll|All Files (*.*)|*.*";

--- a/Tests/SymbolMapReuse.Test/SymbolMapReuse.Test.csproj
+++ b/Tests/SymbolMapReuse.Test/SymbolMapReuse.Test.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net462</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Confuser.UnitTest\Confuser.UnitTest.csproj" />
+    <ProjectReference Include="..\AntiTamper\AntiTamper.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Tests/SymbolMapReuse.Test/SymbolMapReuseTest.cs
+++ b/Tests/SymbolMapReuse.Test/SymbolMapReuseTest.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Confuser.Core;
+using Confuser.Core.Project;
+using Confuser.UnitTest;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SymbolMapReuse.Test {
+	public sealed class SymbolMapReuseTest {
+		readonly ITestOutputHelper output;
+
+		public SymbolMapReuseTest(ITestOutputHelper output) => this.output = output;
+
+		// Obfuscation names are deterministic per seed, so two runs with different seeds normally
+		// produce different names. With InputSymbolMap set to a previous run's symbols.map, the
+		// renamer must reuse those names — so re-obfuscation stays consistent across builds even
+		// when the seed (or code) changes. This is the core guarantee of issue #26.
+		[Fact]
+		[Trait("Category", "Renamer")]
+		[Trait("Issue", "https://github.com/mcpolo99/ConfuserExx/issues/26")]
+		public async Task InputSymbolMap_ReusesNames_AcrossDifferentSeeds() {
+			var baseDir = Environment.CurrentDirectory;
+			const string subject = "AntiTamper.exe";
+			Assert.True(File.Exists(Path.Combine(baseDir, subject)), $"Test subject {subject} not found in {baseDir}");
+
+			// Run 1 — fresh names with seed A.
+			var map1 = await ObfuscateAndReadMap(baseDir, subject, seed: "SeedAAAAAAAA", inputMap: null, suffix: "-map-run1");
+			Assert.NotEmpty(map1);
+
+			// Run 2 — DIFFERENT seed, but feed run 1's map back in: names must be reused.
+			var run1MapPath = Path.Combine(baseDir, "obf-map-run1", "symbols.map");
+			var map2 = await ObfuscateAndReadMap(baseDir, subject, seed: "SeedBBBBBBBB", inputMap: run1MapPath, suffix: "-map-run2");
+			Assert.Equal(map1, map2);
+
+			// Control — different seed, NO input map: names must differ (proving reuse caused the match).
+			var map3 = await ObfuscateAndReadMap(baseDir, subject, seed: "SeedBBBBBBBB", inputMap: null, suffix: "-map-run3");
+			Assert.NotEqual(map1, map3);
+		}
+
+		async Task<List<string>> ObfuscateAndReadMap(string baseDir, string subject, string seed, string inputMap, string suffix) {
+			var outputDir = Path.Combine(baseDir, "obf" + suffix);
+			if (Directory.Exists(outputDir))
+				Directory.Delete(outputDir, true);
+
+			var proj = new ConfuserProject {
+				BaseDirectory = baseDir,
+				OutputDirectory = outputDir,
+				Seed = seed,
+				InputSymbolMap = inputMap
+			};
+			proj.Add(new ProjectModule { Path = subject });
+
+			var rule = new Rule();
+			// Decodable mode records every rename in symbols.map, giving a stable map to compare.
+			rule.Add(new SettingItem<Protection>("rename") { { "mode", "decodable" } });
+			proj.Rules.Add(rule);
+
+			var logger = new XunitLogger(output);
+			await ConfuserEngine.Run(new ConfuserParameters {
+				Project = proj,
+				Logger = logger,
+				ProgressReporter = logger
+			});
+
+			var mapPath = Path.Combine(outputDir, "symbols.map");
+			Assert.True(File.Exists(mapPath), $"symbols.map should be produced in {outputDir}");
+
+			// Return the mapping lines sorted, so comparison is order-insensitive.
+			return File.ReadAllLines(mapPath)
+				.Where(line => !string.IsNullOrWhiteSpace(line))
+				.OrderBy(line => line, StringComparer.Ordinal)
+				.ToList();
+		}
+	}
+}


### PR DESCRIPTION
Implements `InputSymbolMap` (upstream mkaring#168 / yck1509#680) — feed a previous run's `symbols.map` back in so re-obfuscation produces the **same obfuscated names** across builds. This lets you patch already-deployed obfuscated software without replacing every assembly.

Fixes #26

## How it works
The renamer already reuses a name if the original is in `_originalToObfuscatedNameMap`. This PR pre-populates that map from a previous `symbols.map`:

- **`ConfuserProject`** gains an `inputSymbolMap` attribute (Save/Load/Clone + XSD schema entry — Load validates against the XSD).
- **`NameService`** loads the map on construction (path relative to the project base dir). Missing file / parse errors log a warning and fall back to fresh names — never crash.
- When a map is in use, names for **all** rename modes are recorded (not just Decodable/Sequential), so the exported `symbols.map` stays complete and chainable across successive builds.

## Surfaces
- **CLI**: `--map=<file>` flag.
- **GUI**: an "Input Symbol Map" field in the project Advanced Settings dialog (text box with file drag-drop + browse button), bound to the project model.
- **.crproj**: `<project ... inputSymbolMap="previous/symbols.map">`.

Backward compatible — with no map supplied, `hasInputMap` is false and every new path is skipped, so existing behaviour is unchanged.

## Test
`SymbolMapReuse.Test` obfuscates the sample **twice with different seeds**:
- run 2 (different seed + input map) → map **equals** run 1 (names reused)
- control (different seed, no map) → map **differs** from run 1

This proves reuse is what causes the consistency. Existing renamer tests (MessageDeobfuscation, MethodOverloading) still green; full solution + GUI build clean.