### PR TITLE
feature: randomize anti-tamper feedback + CFG multiplier constants (#69 level 2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Visual Studio Cache files (starting with VS 2015)
 .vs/
+.temp
 
 # Launch Settings
 launchSettings.json

--- a/Confuser.Protections/AntiTamper/AntiMode.cs
+++ b/Confuser.Protections/AntiTamper/AntiMode.cs
@@ -16,6 +16,7 @@ using MethodBody = dnlib.DotNet.Writer.MethodBody;
 namespace Confuser.Protections.AntiTamper {
 	internal class AntiMode : IModeHandler {
 		uint c;
+		uint feedback;
 		IKeyDeriver deriver;
 
 		List<MethodDef> methods;
@@ -31,6 +32,7 @@ namespace Confuser.Protections.AntiTamper {
 			x = random.NextUInt32();
 			c = random.NextUInt32();
 			v = random.NextUInt32();
+			feedback = random.NextUInt32();
 			name1 = random.NextUInt32() & 0x7f7f7f7f;
 			name2 = random.NextUInt32() & 0x7f7f7f7f;
 
@@ -77,8 +79,8 @@ namespace Confuser.Protections.AntiTamper {
 				initMethod.Body.Instructions.Add(instr);
 
 			MutationHelper.InjectKeys(initMethod,
-									  new[] { 0, 1, 2, 3, 4 },
-									  new[] { (int)(name1 * name2), (int)z, (int)x, (int)c, (int)v });
+									  new[] { 0, 1, 2, 3, 4, 5 },
+									  new[] { (int)(name1 * name2), (int)z, (int)x, (int)c, (int)v, (int)feedback });
 
 			var name = context.Registry.GetService<INameService>();
 			var marker = context.Registry.GetService<IMarkerService>();
@@ -219,7 +221,7 @@ namespace Confuser.Protections.AntiTamper {
 			for (uint i = 0; i < encSize; i++) {
 				uint data = reader.ReadUInt32();
 				result[i] = data ^ key[i & 0xf];
-				key[i & 0xf] = (key[i & 0xf] ^ data) + 0x3dbb2819;
+				key[i & 0xf] = (key[i & 0xf] ^ data) + feedback;
 			}
 			var byteResult = new byte[encSize << 2];
 			Buffer.BlockCopy(result, 0, byteResult, 0, byteResult.Length);

--- a/Confuser.Protections/AntiTamper/NormalMode.cs
+++ b/Confuser.Protections/AntiTamper/NormalMode.cs
@@ -16,6 +16,7 @@ using MethodBody = dnlib.DotNet.Writer.MethodBody;
 namespace Confuser.Protections.AntiTamper {
 	internal class NormalMode : IModeHandler {
 		uint c;
+		uint feedback;
 		IKeyDeriver deriver;
 
 		List<MethodDef> methods;
@@ -31,6 +32,7 @@ namespace Confuser.Protections.AntiTamper {
 			x = random.NextUInt32();
 			c = random.NextUInt32();
 			v = random.NextUInt32();
+			feedback = random.NextUInt32();
 			name1 = random.NextUInt32() & 0x7f7f7f7f;
 			name2 = random.NextUInt32() & 0x7f7f7f7f;
 
@@ -77,8 +79,8 @@ namespace Confuser.Protections.AntiTamper {
 				initMethod.Body.Instructions.Add(instr);
 
 			MutationHelper.InjectKeys(initMethod,
-									  new[] { 0, 1, 2, 3, 4 },
-									  new[] { (int)(name1 * name2), (int)z, (int)x, (int)c, (int)v });
+									  new[] { 0, 1, 2, 3, 4, 5 },
+									  new[] { (int)(name1 * name2), (int)z, (int)x, (int)c, (int)v, (int)feedback });
 
 			var name = context.Registry.GetService<INameService>();
 			var marker = context.Registry.GetService<IMarkerService>();
@@ -220,7 +222,7 @@ namespace Confuser.Protections.AntiTamper {
 			for (uint i = 0; i < encSize; i++) {
 				uint data = reader.ReadUInt32();
 				result[i] = data ^ key[i & 0xf];
-				key[i & 0xf] = (key[i & 0xf] ^ data) + 0x3dbb2819;
+				key[i & 0xf] = (key[i & 0xf] ^ data) + feedback;
 			}
 			var byteResult = new byte[encSize << 2];
 			Buffer.BlockCopy(result, 0, byteResult, 0, byteResult.Length);

--- a/Confuser.Protections/Constants/CEContext.cs
+++ b/Confuser.Protections/Constants/CEContext.cs
@@ -35,6 +35,7 @@ namespace Confuser.Protections.Constants {
 		public TypeDef CfgCtxType;
 		public MethodDef CfgCtxCtor;
 		public MethodDef CfgCtxNext;
+		public uint CfgCtxMultiplier;
 		public Dictionary<MethodDef, List<Tuple<Instruction, uint, IMethod>>> ReferenceRepl;
 	}
 

--- a/Confuser.Protections/Constants/ReferenceReplacer.cs
+++ b/Confuser.Protections/Constants/ReferenceReplacer.cs
@@ -51,11 +51,11 @@ namespace Confuser.Protections.Constants {
 			public uint C;
 			public uint D;
 
-			public CFGState(uint seed) {
-				A = seed *= 0x21412321;
-				B = seed *= 0x21412321;
-				C = seed *= 0x21412321;
-				D = seed *= 0x21412321;
+			public CFGState(uint seed, uint mult) {
+				A = seed *= mult;
+				B = seed *= mult;
+				C = seed *= mult;
+				D = seed *= mult;
 			}
 
 			public void UpdateExplicit(int id, uint value) {
@@ -136,6 +136,15 @@ namespace Confuser.Protections.Constants {
 				ctx.CfgCtxCtor = ctx.CfgCtxType.FindMethod(".ctor");
 				ctx.CfgCtxNext = ctx.CfgCtxType.FindMethod("Next");
 
+				// Randomize the CFG state multiplier so the baked-in 0x21412321 literal
+				// no longer fingerprints the output. Must stay odd (invertible mod 2^32) and
+				// match the obfuscator-side CFGState computation (see CFGState.ctor).
+				ctx.CfgCtxMultiplier = ctx.Random.NextUInt32() | 1;
+				foreach (var instr in ctx.CfgCtxCtor.Body.Instructions) {
+					if (instr.OpCode == OpCodes.Ldc_I4 && (int)instr.Operand == 0x21412321)
+						instr.Operand = (int)ctx.CfgCtxMultiplier;
+				}
+
 				ctx.Name.MarkHelper(ctx.CfgCtxType, ctx.Marker, ctx.Protection);
 				foreach (var def in ctx.CfgCtxType.Fields)
 					ctx.Name.MarkHelper(def, ctx.Marker, ctx.Protection);
@@ -212,7 +221,7 @@ namespace Confuser.Protections.Constants {
 				if (!ctx.StatesMap.TryGetValue(key.ExitState, out exit)) {
 					// Create new exit state from random seed
 					var seed = ctx.Random.NextUInt32();
-					exit = new CFGState(seed);
+					exit = new CFGState(seed, ctx.Ctx.CfgCtxMultiplier);
 					body.Instructions.Insert(targetIndex++, first = Instruction.Create(OpCodes.Ldloca, ctx.StateVariable));
 					body.Instructions.Insert(targetIndex++, Instruction.Create(OpCodes.Ldc_I4, (int)seed));
 					body.Instructions.Insert(targetIndex++, Instruction.Create(OpCodes.Call, ctx.Ctx.CfgCtxCtor));
@@ -301,7 +310,7 @@ namespace Confuser.Protections.Constants {
 				if (targetState == null) {
 					// Create new exit state from random seed
 					var seed = ctx.Random.NextUInt32();
-					currentState = new CFGState(seed);
+					currentState = new CFGState(seed, ctx.Ctx.CfgCtxMultiplier);
 					body.Instructions.Insert(index++, Instruction.Create(OpCodes.Ldloca, ctx.StateVariable));
 					body.Instructions.Insert(index++, Instruction.Create(OpCodes.Dup));
 					body.Instructions.Insert(index++, Instruction.Create(OpCodes.Ldc_I4, (int)seed));
@@ -398,7 +407,7 @@ namespace Confuser.Protections.Constants {
 
 					// Create new entry state
 					uint blockSeed = ctx.Random.NextUInt32();
-					currentState = new CFGState(blockSeed);
+					currentState = new CFGState(blockSeed, ctx.CfgCtxMultiplier);
 					cfgCtx.StatesMap[key.EntryState] = currentState;
 
 					var index = graph.Body.Instructions.IndexOf(graph[blockRef.Key].Header);

--- a/Confuser.Runtime/AntiTamper.Anti.cs
+++ b/Confuser.Runtime/AntiTamper.Anti.cs
@@ -27,6 +27,7 @@ namespace Confuser.Runtime {
 			uint l = 0;
 			var r = (uint*)(p + 0x18 + o);
 			uint z = (uint)Mutation.KeyI1, x = (uint)Mutation.KeyI2, c = (uint)Mutation.KeyI3, v = (uint)Mutation.KeyI4;
+			uint fb = (uint)Mutation.KeyI5;
 
 			CheckRemoteDebuggerPresent(Process.GetCurrentProcess().Handle, ref isDebuggerPresent);
 			if (isDebuggerPresent) Environment.FailFast(null);
@@ -80,7 +81,7 @@ namespace Confuser.Runtime {
 			uint h = 0;
 			for (uint i = 0; i < l; i++) {
 				*e ^= y[h & 0xf];
-				y[h & 0xf] = (y[h & 0xf] ^ (*e++)) + 0x3dbb2819;
+				y[h & 0xf] = (y[h & 0xf] ^ (*e++)) + fb;
 
 				CheckRemoteDebuggerPresent(Process.GetCurrentProcess().Handle, ref isDebuggerPresent);
 				if (isDebuggerPresent) Environment.FailFast(null);

--- a/Confuser.Runtime/AntiTamper.Normal.cs
+++ b/Confuser.Runtime/AntiTamper.Normal.cs
@@ -20,6 +20,7 @@ namespace Confuser.Runtime {
 			uint l = 0;
 			var r = (uint*)(p + 0x18 + o);
 			uint z = (uint)Mutation.KeyI1, x = (uint)Mutation.KeyI2, c = (uint)Mutation.KeyI3, v = (uint)Mutation.KeyI4;
+			uint fb = (uint)Mutation.KeyI5;
 			for (int i = 0; i < s; i++) {
 				uint g = (*r++) * (*r++);
 				if (g == (uint)Mutation.KeyI0) {
@@ -60,7 +61,7 @@ namespace Confuser.Runtime {
 			uint h = 0;
 			for (uint i = 0; i < l; i++) {
 				*e ^= y[h & 0xf];
-				y[h & 0xf] = (y[h & 0xf] ^ (*e++)) + 0x3dbb2819;
+				y[h & 0xf] = (y[h & 0xf] ^ (*e++)) + fb;
 				h++;
 			}
 		}


### PR DESCRIPTION
## Level 2 constant randomization (#69)

Removes fixed magic constants that de4dot and AV engines pattern-match to fingerprint ConfuserEx output. Each is replaced with a per-run random value, kept in sync between the obfuscator's encryption side and the injected runtime's decryption side via the existing mutation/injection mechanism.

### Included in this PR

| Constant | Files | Constraint | Validation |
|----------|-------|-----------|------------|
| Anti-tamper feedback `0x3dbb2819` | `AntiTamper/NormalMode.cs`, `AntiMode.cs` ↔ `Runtime/AntiTamper.Normal.cs`, `AntiTamper.Anti.cs` | any value (additive) | `AntiTamper.Test` (normal + anti modes) |
| CFG state multiplier `0x21412321` | `Constants/ReferenceReplacer.cs` ↔ `Runtime/Constant.cs` (CFGCtx) | odd (invertible mod 2^32) | `270_EnumArrayConstantProtection.Test`, `193_ConstantsInlining.Test` |

Both changes round-trip through **obfuscate → run → assert output**, so a broken constant sync fails the test immediately.

### How sync is preserved
- **Anti-tamper:** the mode generates `feedback = random.NextUInt32()`, uses it in the encrypt loop, and injects the same value into the runtime placeholder via `MutationHelper.InjectKeys` (slot 5).
- **CFG multiplier:** on runtime `CFGCtx` injection, a random odd multiplier is generated, the `0x21412321` literal is rewritten in the injected ctor IL, and the same value is threaded through the obfuscator-side `CFGState` constructor.

### Intentionally scoped out (follow-up)
- JIT anti-tamper mode (its runtime test is skipped/broken — can't validate).
- Compressor feedback `0x3ddb2819`, LCG constants, prime moduli, xorshift/rotation triples — require signature changes and/or curated valid-value sets; tracked in `.temp/issue-69-analysis.md`.

Part of #69.
