### PR TITLE
chore: pin .cs line endings to LF for deterministic formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -19,6 +19,7 @@ indent_size = 4
 indent_style = space
 
 [*.{cs,vb}]
+end_of_line = lf
 dotnet_separate_import_directive_groups = false
 dotnet_sort_system_directives_first = true
 dotnet_style_coalesce_expression = true:suggestion

--- a/.gitattributes
+++ b/.gitattributes
@@ -4,7 +4,7 @@
 # Explicitly declare text files we want to always be normalized and converted
 # to native line endings on checkout.
 *.config text
-*.cs text diff=csharp
+*.cs text eol=lf diff=csharp
 *.manifest text
 *.md text
 *.resx text


### PR DESCRIPTION
## Problem

`dotnet format` has no `end_of_line` setting in `.editorconfig`, so it falls back to the OS default — **CRLF on Windows**, LF on Linux. Combined with `.gitattributes '*.cs text'` (native eol on checkout), local `dotnet format --verify` results depend on each contributor's `core.autocrlf`:

- CI (windows-2025, `autocrlf=true`) checks out CRLF → **passes** (green today).
- A contributor with `core.autocrlf=input` checks out LF → `dotnet format` wants CRLF → **spurious whitespace failures** (e.g. `SymbolMapReuseTest.cs` in local-ci).

There is **no actual whitespace defect** in any file — it's purely nondeterministic line-ending handling.

## Fix

Pin `.cs` to LF on both sides so formatting is deterministic on every platform:
- `.editorconfig`: `end_of_line = lf` under `[*.{cs,vb}]`
- `.gitattributes`: `*.cs text eol=lf`

Blobs are already LF (`git add --renormalize` was a no-op), so this changes **no file content** — only how `.cs` is checked out and what `dotnet format` expects. VS project files remain `eol=crlf` as before.

## Verification

`bash scripts/local-ci.sh lint` → Whitespace OK, Style OK, Analyzers OK on `core.autocrlf=input` (previously failed).